### PR TITLE
Implement ticket reactions

### DIFF
--- a/app/Channels/Messages/DiscordMessage.php
+++ b/app/Channels/Messages/DiscordMessage.php
@@ -19,6 +19,7 @@ class DiscordMessage
     public const INFO = 10181046;
 
     private $fields = [];
+    private $messageId;
 
     /**
      * Use info-coded color.
@@ -59,6 +60,13 @@ class DiscordMessage
     public function to($channel)
     {
         $this->channel = $channel;
+
+        return $this;
+    }
+
+    public function messageId($messageId)
+    {
+        $this->messageId = $messageId;
 
         return $this;
     }
@@ -116,6 +124,7 @@ class DiscordMessage
                     ],
                     'fields' => $this->fields,
                 ],
+                'id' => $this->messageId
             ]) . "'";
 
         return [

--- a/app/Channels/Messages/DiscordMessage.php
+++ b/app/Channels/Messages/DiscordMessage.php
@@ -124,7 +124,7 @@ class DiscordMessage
                     ],
                     'fields' => $this->fields,
                 ],
-                'id' => $this->messageId
+                'id' => $this->messageId,
             ]) . "'";
 
         return [

--- a/app/Channels/Messages/DiscordMessageReact.php
+++ b/app/Channels/Messages/DiscordMessageReact.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Channels\Messages;
+
+class DiscordMessageReact
+{
+    public const RESOLVED = '✅';
+    public const REJECTED = '❌';
+    public const ASSIGNED = '⏳';
+    private string $emote;
+    private string $messageId;
+    private string $channel;
+
+    public function to(string $channel)
+    {
+        $this->channel = $channel;
+
+        return $this;
+    }
+
+    public function messageId(string $messageId)
+    {
+        $this->messageId = $messageId;
+
+        return $this;
+    }
+
+    public function status(string $status)
+    {
+        $statuses = [
+            'assigned' => self::ASSIGNED,
+            'rejected' => self::REJECTED,
+            'resolved' => self::RESOLVED,
+        ];
+
+        if (!isset($statuses[$status])) {
+            throw new \Exception("Invalid status provided to DiscordMessageReact");
+        }
+
+        $this->emote = $statuses[$status];
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     *
+     * @throws Exception
+     */
+    public function send()
+    {
+        if (!$this->channel) {
+            throw new Exception('A channel must be defined');
+        }
+
+        if (!$this->emote) {
+            throw new Exception('A status {assigned, resolved, rejected} must be defined');
+        }
+
+        if (!isset($this->messageId)) {
+            throw new Exception('A message id must be defined');
+        }
+
+        return [
+            'content' => "!react {$this->channel} relayed {$this->messageId} {$this->emote}",
+        ];
+    }
+}
+
+
+

--- a/app/Channels/Messages/DiscordMessageReact.php
+++ b/app/Channels/Messages/DiscordMessageReact.php
@@ -34,7 +34,7 @@ class DiscordMessageReact
         ];
 
         if (!isset($statuses[$status])) {
-            throw new \Exception("Invalid status provided to DiscordMessageReact");
+            throw new \Exception('Invalid status provided to DiscordMessageReact');
         }
 
         $this->emote = $statuses[$status];
@@ -66,6 +66,3 @@ class DiscordMessageReact
         ];
     }
 }
-
-
-

--- a/app/Channels/Messages/DiscordMessageReact.php
+++ b/app/Channels/Messages/DiscordMessageReact.php
@@ -57,7 +57,7 @@ class DiscordMessageReact
             throw new Exception('A status {assigned, resolved, rejected} must be defined');
         }
 
-        if (!isset($this->messageId)) {
+        if (!$this->messageId) {
             throw new Exception('A message id must be defined');
         }
 

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -9,6 +9,7 @@ use App\Notifications\NotifyAdminTicketCreated;
 use App\Notifications\NotifyCallerTicketUpdated;
 use App\Notifications\NotifyNewTicketOwner;
 use App\Notifications\NotifyUserTicketCreated;
+use App\Notifications\TicketReaction;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -102,6 +103,7 @@ class TicketController extends Controller
         $ticket->state = 'new';
         $ticket->ticket_type_id = $validated['ticket_type'];
         $ticket->description = $validated['description'];
+        $ticket->message_id = \Ramsey\Uuid\Uuid::uuid4()->toString();
         $ticket->caller_id = auth()->id();
         $ticket->division_id = auth()->user()->member->division_id;
         $ticket->save();
@@ -138,6 +140,7 @@ class TicketController extends Controller
         $this->showToast($message);
 
         $ticket->notify(new NotifyCallerTicketUpdated(':white_check_mark: ' . $message));
+        $ticket->notify(new TicketReaction('resolved'));
 
         return redirect(route('help.tickets.show', $ticket));
     }
@@ -168,6 +171,7 @@ class TicketController extends Controller
         $this->showToast($message);
 
         $ticket->notify(new NotifyCallerTicketUpdated($message));
+        $ticket->notify(new TicketReaction('rejected'));
 
         return redirect(route('help.tickets.show', $ticket));
     }
@@ -188,6 +192,7 @@ class TicketController extends Controller
 
         $ticket->notify(new NotifyCallerTicketUpdated($message));
         $ticket->notify(new NotifyNewTicketOwner($assignedUser, auth()->user()));
+        $ticket->notify(new TicketReaction('assigned'));
 
         return redirect(route('help.tickets.show', $ticket));
     }

--- a/app/Notifications/NotifyAdminTicketCreated.php
+++ b/app/Notifications/NotifyAdminTicketCreated.php
@@ -36,6 +36,7 @@ class NotifyAdminTicketCreated extends Notification
 
         return (new DiscordMessage())
             ->to($channel)
+            ->messageId($ticket->message_id)
             ->info()
             ->fields([
                 [

--- a/app/Notifications/TicketReaction.php
+++ b/app/Notifications/TicketReaction.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Channels\Messages\DiscordMessageReact;
+use App\Channels\WebhookChannel;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Notification;
+
+class TicketReaction extends Notification
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     *
+     * @return void
+     */
+    public function __construct(private string $status)
+    {
+        //
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function via($notifiable)
+    {
+        return [WebhookChannel::class];
+    }
+
+    /**
+     * @param $ticket
+     * @return array
+     *
+     * @throws \Exception
+     */
+    public function toWebhook($ticket)
+    {
+        return (new DiscordMessageReact())
+            ->to(channel: config('app.aod.admin-ticketing-channel'))
+            ->messageId($ticket->message_id)
+            ->status($this->status)
+            ->send();
+    }
+}

--- a/database/factories/TicketFactory.php
+++ b/database/factories/TicketFactory.php
@@ -4,6 +4,7 @@ namespace Database\Factories;
 
 use App\Models\Ticket;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Ramsey\Uuid\Uuid;
 
 class TicketFactory extends Factory
 {
@@ -28,6 +29,7 @@ class TicketFactory extends Factory
             'caller_id' => \App\Models\User::inRandomOrder()->first()->id,
             'division_id' => \App\Models\Division::inRandomOrder()->active()->get()->first()->id,
             'description' => $this->faker->paragraph,
+            'message_id' => Uuid::uuid4()->toString(),
             'owner_id' => 'assigned' === $states[$randomState]
                 ? \App\Models\User::whereRoleId(5)->inRandomOrder()->first()->id
                 : null,

--- a/database/migrations/2023_05_17_143601_add_message_id_to_tickets_table.php
+++ b/database/migrations/2023_05_17_143601_add_message_id_to_tickets_table.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class extends Migration {
     /**
      * Run the migrations.
      *

--- a/database/migrations/2023_05_17_143601_add_message_id_to_tickets_table.php
+++ b/database/migrations/2023_05_17_143601_add_message_id_to_tickets_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('tickets', function (Blueprint $table) {
+            $table->uuid('message_id')->after('ticket_type_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('tickets', function (Blueprint $table) {
+            //
+        });
+    }
+};


### PR DESCRIPTION
Leverages the discord bot command `!react` to apply reacts based on resolution, rejection, and assignment of tickets. Mostly a helper process for admins to see that tickets have been handled (or not) without clicking into them