### PR TITLE
Implement Discord data, reports

### DIFF
--- a/app/Http/Controllers/Division/ReportController.php
+++ b/app/Http/Controllers/Division/ReportController.php
@@ -90,6 +90,21 @@ class ReportController extends \App\Http\Controllers\Controller
     }
 
     /**
+     * @param  Division  $division
+     * @return \Illuminate\Contracts\Foundation\Application|Factory|\Illuminate\Contracts\View\View
+     */
+    public function voiceReport(Division $division)
+    {
+        $issues = $division->membersOfDiscordState([
+            'never_connected',
+            'never_configured',
+            'disconnected',
+        ])->get();
+
+        return view('division.reports.voice-report', compact('division', 'issues'));
+    }
+
+    /**
      * @return Factory|View
      */
     public function censusReport(Division $division)

--- a/app/Models/Member.php
+++ b/app/Models/Member.php
@@ -36,10 +36,12 @@ class Member extends Model
 
     protected $guarded = [];
 
+    // @TODO: replace with casts
     protected $dates = [
         'join_date',
         'last_activity',
         'last_ts_activity',
+        'last_voice_activity',
         'last_promoted_at',
         // sgt info
         'last_trained_at',
@@ -314,4 +316,5 @@ class Member extends Model
     {
         return $this->hasMany(MemberRequest::class, 'requester_id', 'clan_id');
     }
+
 }

--- a/app/Models/Member/HasCustomAttributes.php
+++ b/app/Models/Member/HasCustomAttributes.php
@@ -4,27 +4,28 @@ namespace App\Models\Member;
 
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Support\Str;
 
 trait HasCustomAttributes
 {
     public function AODProfileLink(): Attribute
     {
         return new Attribute(
-            fn ($value, $attributes) => 'http://www.clanaod.net/forums/member.php?u=' . $attributes['clan_id']
+            fn($value, $attributes) => 'http://www.clanaod.net/forums/member.php?u='.$attributes['clan_id']
         );
     }
 
     public function tsInvalid(): Attribute
     {
         return new Attribute(
-            fn ($value, $attributes) => null === carbon_date_or_null_if_zero($attributes['last_ts_activity'])
+            fn($value, $attributes) => null === carbon_date_or_null_if_zero($attributes['last_ts_activity'])
         );
     }
 
     public function lastPromoted(): Attribute
     {
         return new Attribute(
-            fn ($value, $attributes) => (\strlen($attributes['last_promoted_at']))
+            fn($value, $attributes) => (\strlen($attributes['last_promoted_at']))
                 ? Carbon::parse($attributes['last_promoted_at'])->format('Y-m-d')
                 : 'Never'
         );
@@ -33,7 +34,18 @@ trait HasCustomAttributes
     public function isPending(): Attribute
     {
         return new Attribute(
-            fn ($value, $attributes) => $this->memberRequest()->pending()->exists()
+            fn($value, $attributes) => $this->memberRequest()->pending()->exists()
         );
     }
+
+    public function voiceStatus(): Attribute
+    {
+        return new Attribute(
+            fn($value, $attributes) => Str::of($attributes['last_voice_status'])
+                ->snake()
+                ->replace('_', ' ')
+                ->title()
+        );
+    }
+
 }

--- a/database/migrations/2024_03_21_080438_add_discord_data_to_member_sync.php
+++ b/database/migrations/2024_03_21_080438_add_discord_data_to_member_sync.php
@@ -29,9 +29,9 @@ return new class() extends Migration
             $table->string('tsid');
             $table->string('lastts_connect');
             $table->string('lastts_connect_time');
-            $table->string('lastdiscord_connect');
-            $table->string('lastdiscord_connect_time');
-            $table->string('lastdiscord_status');
+            $table->string('lastdiscord_connect'); // last day in a voice channel
+            $table->string('lastdiscord_connect_time'); // last time in a voice channel
+            $table->string('lastdiscord_status'); // discord connection
             $table->string('aodrank');
             $table->integer('aodrankval');
             $table->string('aoddivision');

--- a/database/migrations/2024_03_21_083940_add_discord_member_data.php
+++ b/database/migrations/2024_03_21_083940_add_discord_member_data.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('members', function (Blueprint $table) {
+            $table->dateTime('last_voice_activity')->after('discord')->nullable();
+            $table->string('last_voice_status')->after('last_voice_activity')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('members', function (Blueprint $table) {
+            $table->dropColumn('last_voice_activity');
+        });
+    }
+};

--- a/resources/views/application/header.blade.php
+++ b/resources/views/application/header.blade.php
@@ -12,8 +12,7 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.css"/>
 {{--<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"/>--}}
 
-<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.5.0/css/all.css"
-      integrity="sha384-B4dIYHKNBt8Bc12p+WXckhzcICo0wtJAoU8YZTY5qE0Id1GSseTk6S+L3BlXeVIU" crossorigin="anonymous">
+<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.4/css/all.css" crossorigin="anonymous">
 
 <link rel="stylesheet" href="{{ asset('vendor/animate.css/animate.css') }}"/>
 <link rel="stylesheet" href="{{ asset('vendor/toastr/toastr.min.css') }}"/>

--- a/resources/views/division/partials/tools-links.blade.php
+++ b/resources/views/division/partials/tools-links.blade.php
@@ -66,6 +66,10 @@
             <a href="{{ route('division.retention-report', $division) }}">Member Retention</a>
         </li>
 
+        <li>
+            <a href="{{ route('division.voice-report', $division) }}">Voice Issues</a>
+        </li>
+
         <?php $file = Str::camel($division->name); ?>
         @if (file_exists(resource_path("views/division/reports/ingame-reports/{$file}.blade.php")))
             <li>

--- a/resources/views/division/partials/voice-status.blade.php
+++ b/resources/views/division/partials/voice-status.blade.php
@@ -1,0 +1,15 @@
+@if($status === 'never_connected')
+    <span class="text-muted">Never connected</span>
+@endif
+
+@if($status === 'never_configured')
+    <span class="text-warning">Never configured</span>
+@endif
+
+@if($status === 'connected')
+    <span class="text-success">Connected</span>
+@endif
+
+@if($status === 'disconnected')
+    <span class="text-danger">Disconnected</span>
+@endif

--- a/resources/views/division/reports/voice-report.blade.php
+++ b/resources/views/division/reports/voice-report.blade.php
@@ -71,8 +71,7 @@
         <div class="panel-body">
                <p><strong class="text-danger">Disconnected</strong>: User was connected but not anymore.</p>
                <p> <strong class="text-muted">Never Connected</strong>: User has never connected to the AOD Discord.</p>
-               <p> <strong class="text-warning">Never Configured</strong>: User has not provided Discord information to AOD
-                   .</p>
+               <p> <strong class="text-warning">Never Configured</strong>: User has not provided Discord information to AOD.</p>
         </div>
     </div>
 

--- a/resources/views/division/reports/voice-report.blade.php
+++ b/resources/views/division/reports/voice-report.blade.php
@@ -30,7 +30,7 @@
                 <tr>
                     <th>Member</th>
                     <th>State</th>
-                    <th>{{ $division->locality('platoon')}}</th>
+                    <th>{{ $division->locality('platoon') }}</th>
                     <th>Last Activity</th>
                 </tr>
                 </thead>

--- a/resources/views/division/reports/voice-report.blade.php
+++ b/resources/views/division/reports/voice-report.blade.php
@@ -1,0 +1,79 @@
+@extends('application.base-tracker')
+
+@section('content')
+
+    @component ('application.components.division-heading')
+        @slot ('icon')
+            <img src="{{ getDivisionIconPath($division->abbreviation) }}" class="division-icon-large"/>
+        @endslot
+        @slot ('heading')
+            Voice Report
+        @endslot
+        @slot ('subheading')
+            {{ $division->name }} Division
+        @endslot
+    @endcomponent
+
+    <div class="container-fluid">
+
+        {!! Breadcrumbs::render('voice-report', $division) !!}
+
+        @if (count($issues))
+            <h4 class="m-t-xl">
+                <i class="fa fa-exclamation-triangle text-danger"></i> Affected members
+                <span class="pull-right text-muted">{{ count($issues) }} Issues</span>
+            </h4>
+            <hr/>
+
+            <table class="table table-hover adv-datatable">
+                <thead>
+                <tr>
+                    <th>Member</th>
+                    <th>State</th>
+                    <th>{{ $division->locality('platoon')}}</th>
+                    <th>Last Activity</th>
+                </tr>
+                </thead>
+                <tbody>
+                @foreach ($issues as $member)
+                    <tr>
+                        <td>
+                            <a href="{{ route('member', $member->getUrlParams()) }}"><i class="fa fa-search"></i></a>
+                            {{ $member->present()->rankName }}
+                        </td>
+                        <td>
+                            @include('division.partials.voice-status', ['status' =>  $member->last_voice_status])
+                        </td>
+                        <td>
+                            {{ $member->platoon->name }}
+                        </td>
+                        <td>
+                            {{-- temporary handling of null dates --}}
+                            @if(str_contains($member->last_voice_activity, '1970'))
+                                Never
+                            @else
+                                {{ $member->last_voice_activity }}
+                            @endif
+                        </td>
+                    </tr>
+                @endforeach
+                </tbody>
+            </table>
+        @else
+            <p>Congratulations, you have no discord issues!</p>
+        @endif
+    </div>
+
+    <div class="panel panel-filled m-t-xl">
+        <div class="panel-heading">
+            Possible States
+        </div>
+        <div class="panel-body">
+               <p><strong class="text-danger">Disconnected</strong>: User was connected but not anymore.</p>
+               <p> <strong class="text-muted">Never Connected</strong>: User has never connected to the AOD Discord.</p>
+               <p> <strong class="text-warning">Never Configured</strong>: User has not provided Discord information to AOD
+                   .</p>
+        </div>
+    </div>
+
+@endsection

--- a/resources/views/member/partials/general-information.blade.php
+++ b/resources/views/member/partials/general-information.blade.php
@@ -9,7 +9,7 @@
             <div class="panel-body">
 
                 <div class="row">
-                    <div class="col-md-4 col-xs-12 text-center">
+                    <div class="col-md-3 col-xs-12 text-center">
                         <h2 class="no-margins">
                             @if ($member->isPending)
                                 <span class="text-muted">UNAVAILABLE</span>
@@ -24,18 +24,27 @@
                         Since last <span class="c-white">TS activity</span>
                     </div>
 
-                    <div class="col-md-4 col-xs-12 text-center">
+                    <div class="col-md-3 col-xs-12 text-center">
                         <h2 class="no-margins">
                             {{ $member->join_date->format('Y-m-d') }}
                         </h2>
                         Member <span class="c-white">Join Date</span>
                     </div>
 
-                    <div class="col-md-4 col-xs-12 text-center">
+                    <div class="col-md-3 col-xs-12 text-center">
                         <h2 class="no-margins">
                             {{ $member->lastPromoted }}
                         </h2>
                         Last <span class="c-white">Promotion Date</span>
+                    </div>
+
+                    <div class="col-md-3 col-xs-12 text-center">
+                        <h2 class="no-margins" title="{{ $member->voiceStatus . ' - '
+                        . $member->last_voice_activity ??
+                        'N/A' }}">
+                            @include('member.partials.voice-status', ['status' => $member->last_voice_status])
+                        </h2>
+                        Voice <span class="c-white">Status</span>
                     </div>
                 </div>
 

--- a/resources/views/member/partials/voice-status.blade.php
+++ b/resources/views/member/partials/voice-status.blade.php
@@ -1,0 +1,15 @@
+@if($status === 'never_connected')
+    <span class="text-muted"><i class="fas fa-users-slash"></i></span>
+@endif
+
+@if($status === 'never_configured')
+    <span class="text-danger"><i class="fa fa-user-slash"></i></span>
+@endif
+
+@if($status === 'connected')
+    <span class="text-success"><i class="fa fa-user"></i></span>
+@endif
+
+@if($status === 'disconnected')
+    <span class="text-danger"><i class="fas fa-sign-out-alt"></i></span>
+@endif

--- a/routes/Breadcrumbs/division.php
+++ b/routes/Breadcrumbs/division.php
@@ -44,6 +44,7 @@ function registerDivisionSubPages()
         'inactive-members',
         'teamspeak-report',
         'retention-report',
+        'voice-report',
         'ingame-report',
         'promotions',
         'members',

--- a/routes/partials/divisions.php
+++ b/routes/partials/divisions.php
@@ -47,8 +47,8 @@ Route::group(['prefix' => 'divisions/{division}'], function () {
     /*
      * Division Reports.
      */
-    Route::get('/ts-report', 'Division\ReportController@tsReport')
-        ->name('division.ts-report');
+    Route::get('/ts-report', 'Division\ReportController@tsReport')->name('division.ts-report');
+    Route::get('/voice-report', 'Division\ReportController@voiceReport')->name('division.voice-report');
     Route::get('/retention', 'Division\ReportController@retentionReport')
         ->name('division.retention-report');
     Route::get('/census', 'Division\ReportController@censusReport')


### PR DESCRIPTION
This PR adds a few things in support of Discord integration, specifically the need to track activity for members.

- Adds new discord data to member / division forum sync
- Adds a division level report for divisions to identify members with issues
- Adds a discord status to member pages