### PR TITLE
Add an extra year to anniversaries on Division view.

### DIFF
--- a/app/Repositories/DivisionRepository.php
+++ b/app/Repositories/DivisionRepository.php
@@ -95,15 +95,15 @@ class DivisionRepository
                 ->whereRaw("TIMESTAMPDIFF(YEAR, join_date, CURRENT_DATE()) >= 1")
                 ->whereMonth('join_date', now()->month)
                 ->where('division_id', $division->id)
+                ->orderByDesc('years_since_joined')
+                ->orderBy('name')
                 ->get()
                 ->map(function ($member) {
                     // Assuming the anniversary if the day hasn't yet occurred this month
                     $member->years_since_joined += $member->adjustment;
                     unset($member->adjustment);
                     return $member;
-                })
-                ->sortBy('name')
-                ->sortByDesc('years_since_joined');
+                });
     }
 
     /**

--- a/resources/views/division/partials/anniversaries.blade.php
+++ b/resources/views/division/partials/anniversaries.blade.php
@@ -20,7 +20,8 @@
 
             {{ $anniversary->name }}
             <span class="label label-success text-uppercase" style="color:#000;">
-                {{ $anniversary->years_since_joined }} {{ str()->plural('yr', $anniversary->years_since_joined) }}
+                <?php $extraYear = ((Carbon::parse($anniversary->join_date)->day > Carbon::now()->day) ? 1 : 0) ?>
+                {{ $anniversary->years_since_joined + $extraYear }} {{ str()->plural('yr', $anniversary->years_since_joined + $extraYear) }}
             </span>
         </a>
     @endforeach

--- a/resources/views/division/partials/anniversaries.blade.php
+++ b/resources/views/division/partials/anniversaries.blade.php
@@ -8,20 +8,21 @@
         <a href="{{ doForumFunction([$anniversary->clan_id], 'forumProfile') }}&tab=myawards#myawards"
            class="btn btn-default" style="margin-bottom:15px;" target="_blank"
         >
-            @if($anniversary->years_since_joined >= 5)
+
+            <?php $anniversaryYears = $anniversary->years_since_joined + ((Carbon::parse($anniversary->join_date)->day > Carbon::now()->day) ? 1 : 0) ?>
+            @if($anniversaryYears >= 5)
                 <i class="fas fa-trophy fa-sm" style="color: #cd7f32;" title="5+ Years"></i>
-            @elseif($anniversary->years_since_joined >= 10)
+            @elseif($anniversaryYears >= 10)
                 <i class="fas fa-trophy fa-sm" style="color: #C0C0C0;" title="10+ Years"></i>
-            @elseif($anniversary->years_since_joined >= 15)
+            @elseif($anniversaryYears >= 15)
                 <i class="fas fa-trophy fa-md" style="color: #D4AF37;" title="15+ Years"></i>
-            @elseif($anniversary->years_since_joined >= 20)
+            @elseif($anniversaryYears >= 20)
                 <i class="fas fa-trophy fa-lg" title="20+ Years" style="color: #E5E4E2;"></i>
             @endif
 
             {{ $anniversary->name }}
             <span class="label label-success text-uppercase" style="color:#000;">
-                <?php $extraYear = ((Carbon::parse($anniversary->join_date)->day > Carbon::now()->day) ? 1 : 0) ?>
-                {{ $anniversary->years_since_joined + $extraYear }} {{ str()->plural('yr', $anniversary->years_since_joined + $extraYear) }}
+                {{ $anniversaryYears }} {{ str()->plural('yr', $anniversaryYears) }}
             </span>
         </a>
     @endforeach

--- a/resources/views/division/partials/anniversaries.blade.php
+++ b/resources/views/division/partials/anniversaries.blade.php
@@ -8,21 +8,19 @@
         <a href="{{ doForumFunction([$anniversary->clan_id], 'forumProfile') }}&tab=myawards#myawards"
            class="btn btn-default" style="margin-bottom:15px;" target="_blank"
         >
-
-            <?php $anniversaryYears = $anniversary->years_since_joined + ((Carbon::parse($anniversary->join_date)->day > Carbon::now()->day) ? 1 : 0) ?>
-            @if($anniversaryYears >= 5)
+            @if($anniversary->years_since_joined >= 5)
                 <i class="fas fa-trophy fa-sm" style="color: #cd7f32;" title="5+ Years"></i>
-            @elseif($anniversaryYears >= 10)
+            @elseif($anniversary->years_since_joined >= 10)
                 <i class="fas fa-trophy fa-sm" style="color: #C0C0C0;" title="10+ Years"></i>
-            @elseif($anniversaryYears >= 15)
+            @elseif($anniversary->years_since_joined >= 15)
                 <i class="fas fa-trophy fa-md" style="color: #D4AF37;" title="15+ Years"></i>
-            @elseif($anniversaryYears >= 20)
+            @elseif($anniversary->years_since_joined >= 20)
                 <i class="fas fa-trophy fa-lg" title="20+ Years" style="color: #E5E4E2;"></i>
             @endif
 
             {{ $anniversary->name }}
             <span class="label label-success text-uppercase" style="color:#000;">
-                {{ $anniversaryYears }} {{ str()->plural('yr', $anniversaryYears) }}
+                {{ $anniversary->years_since_joined }} {{ str('yr')->plural($anniversary->years_since_joined) }}
             </span>
         </a>
     @endforeach


### PR DESCRIPTION
Update the Anniversaries section on the Division view to indicate the **upcoming** anniversary for the member in that month rather than their current tenure. Extra logic was needed, so the extra day is only added if the date is earlier in the month than their anniversary.