### PR TITLE
Fix trophies again so the 5+ trophy is only displayed for 5+ members

### DIFF
--- a/resources/views/division/partials/anniversaries.blade.php
+++ b/resources/views/division/partials/anniversaries.blade.php
@@ -11,8 +11,6 @@
 
             @php
                 $iconClass = 'fas fa-trophy';
-                $iconColor = '#cd7f32';
-                $iconTitle = '5+ Years';
 
                 if ($anniversary->years_since_joined >= 20) {
                     $iconClass .= ' fa-lg';
@@ -26,10 +24,16 @@
                     $iconClass .= ' fa-sm';
                     $iconColor = '#C0C0C0';
                     $iconTitle = '10+ Years';
+                } elseif ($anniversary->years_since_joined >= 5){
+                    $iconClass .= ' fa-sm';
+                    $iconColor = '#cd7f32';
+                    $iconTitle = '5+ Years';
                 }
             @endphp
 
-            <i class="{{ $iconClass }}" style="color: {{ $iconColor }};" title="{{ $iconTitle }}"></i>
+            @if ($anniversary->years_since_joined >= 5)
+                <i class="{{ $iconClass }}" style="color: {{ $iconColor }};" title="{{ $iconTitle }}"></i>
+            @endif
 
             {{ $anniversary->name }}
             <span class="label label-success text-uppercase" style="color:#000;">


### PR DESCRIPTION
Trophies are showing for members with less than 5 years of membership due to edb010c2cacc322bda8725c112e2c2b7a41c92af. This commit corrects that display.

Current
![image](https://github.com/ClanAODDev/tracker_v3/assets/112572/4addf4ce-ca6a-4e1d-99d1-f1af4c694a33)

Corrected
![image](https://github.com/ClanAODDev/tracker_v3/assets/112572/6f8e52ea-b592-4436-b590-b855e98ade8e)
