### PR TITLE
Port channel-based bot messages over to BotChannel

### DIFF
--- a/app/Channels/Messages/BotMessage.php
+++ b/app/Channels/Messages/BotMessage.php
@@ -17,7 +17,6 @@ class BotMessage
     private mixed $message;
     private int $color;
     private $thumbnail = [];
-    private $messageId;
 
     public function title($title)
     {
@@ -93,17 +92,6 @@ class BotMessage
     }
 
     /**
-     * @param $messageId
-     * @return $this
-     */
-    public function messageId($messageId)
-    {
-        $this->messageId = $messageId;
-
-        return $this;
-    }
-
-    /**
      * @return array
      *
      * @throws Exception
@@ -138,7 +126,6 @@ class BotMessage
                     'url' => $this->url ?? 'https://tracker.clanaod.net',
                 ],
                 'fields' => $this->fields ?? [],
-                'id' => $this->messageId,
                 'thumbnail' => ['url' => $this->thumbnail] ?? [],
             ]],
         ];

--- a/app/Channels/Messages/BotMessage.php
+++ b/app/Channels/Messages/BotMessage.php
@@ -130,7 +130,7 @@ class BotMessage
          */
         return [
             'embeds' => [[
-                'co2lor' => $this->color ?? 0,
+                'color' => $this->color ?? 0,
                 'description' => $this->message ?? "",
                 'author' => [
                     'name' => $this->title,

--- a/app/Channels/Messages/BotMessage.php
+++ b/app/Channels/Messages/BotMessage.php
@@ -16,6 +16,8 @@ class BotMessage
     private $fields = [];
     private mixed $message;
     private int $color;
+    private $thumbnail = [];
+    private $messageId;
 
     public function title($title)
     {
@@ -24,7 +26,7 @@ class BotMessage
         return $this;
     }
 
-    public function thumbnail($thumbnail): static
+    public function thumbnail($thumbnail)
     {
         $this->thumbnail = $thumbnail;
 
@@ -91,14 +93,29 @@ class BotMessage
     }
 
     /**
+     * @param $messageId
+     * @return $this
+     */
+    public function messageId($messageId)
+    {
+        $this->messageId = $messageId;
+
+        return $this;
+    }
+
+    /**
      * @return array
      *
      * @throws Exception
      */
     public function send(): array
     {
-        if (!isset($this->message) || !isset($this->title)) {
-            throw new Exception('A title and message must be defined');
+        if (!isset($this->title)) {
+            throw new Exception('A title must be defined');
+        }
+
+        if (!isset($this->message)  && !isset($this->fields)) {
+            throw new Exception('A message or fields must be defined');
         }
 
         /**
@@ -113,14 +130,15 @@ class BotMessage
          */
         return [
             'embeds' => [[
-                'color' => $this->color ?? 0,
-                'description' => $this->message,
+                'co2lor' => $this->color ?? 0,
+                'description' => $this->message ?? "",
                 'author' => [
                     'name' => $this->title,
                     'icon_url' => 'http://tracker.clanaod.net/images/logo_v2.png',
                     'url' => $this->url ?? 'https://tracker.clanaod.net',
                 ],
                 'fields' => $this->fields ?? [],
+                'id' => $this->messageId,
                 'thumbnail' => ['url' => $this->thumbnail] ?? [],
             ]],
         ];

--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -80,6 +80,18 @@ class Ticket extends Model
     }
 
     /**
+     * @return mixed|Repository
+     */
+    public function routeNotificationForBot()
+    {
+        return sprintf(
+            "%s/channel/%s",
+            config('app.aod.bot_api_base_url'),
+            config('app.aod.admin-ticketing-channel')
+        );
+    }
+
+    /**
      * @return mixed
      */
     public function scopeNew($query)

--- a/app/Notifications/DivisionEdited.php
+++ b/app/Notifications/DivisionEdited.php
@@ -4,8 +4,6 @@ namespace App\Notifications;
 
 use App\Channels\BotChannel;
 use App\Channels\Messages\BotMessage;
-use App\Channels\Messages\DiscordMessage;
-use App\Channels\WebhookChannel;
 use Exception;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -35,19 +33,6 @@ class DivisionEdited extends Notification implements ShouldQueue
      *
      * @throws Exception
      */
-    public function toWebhook($notifiable)
-    {
-        $channel = $notifiable->settings()->get('officer_channel');
-
-        $authoringUser = auth()->check() ? auth()->user()->name : 'ClanAOD';
-
-        return (new DiscordMessage())
-            ->to($channel)
-            ->message(":tools: **{$authoringUser}** updated division settings for **{$notifiable->name}**")
-            ->success()
-            ->send();
-    }
-
     public function toBot($notifiable)
     {
         return (new BotMessage())

--- a/app/Notifications/MemberNameChanged.php
+++ b/app/Notifications/MemberNameChanged.php
@@ -2,8 +2,8 @@
 
 namespace App\Notifications;
 
-use App\Channels\Messages\DiscordMessage;
-use App\Channels\WebhookChannel;
+use App\Channels\BotChannel;
+use App\Channels\Messages\BotMessage;
 use Exception;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -22,7 +22,7 @@ class MemberNameChanged extends Notification implements ShouldQueue
 
     public function via($notifiable)
     {
-        return [WebhookChannel::class];
+        return [BotChannel::class];
     }
 
     /**
@@ -31,12 +31,11 @@ class MemberNameChanged extends Notification implements ShouldQueue
      *
      * @throws Exception
      */
-    public function toWebhook($notifiable)
+    public function toBot($notifiable)
     {
-        $channel = $notifiable->settings()->get('officer_channel');
-
-        return (new DiscordMessage())
-            ->to($channel)
+        return (new BotMessage())
+            ->title($notifiable->name.' Division')
+            ->thumbnail(getDivisionIconPath($notifiable->abbreviation))
             ->message(addslashes(":tools: **MEMBER STATUS - NAME CHANGE**\n`{$this->names['oldName']}` is now known as `{$this->names['newName']}`. Please inform the member of this change."))
             ->success()
             ->send();

--- a/app/Notifications/MemberRemoved.php
+++ b/app/Notifications/MemberRemoved.php
@@ -2,8 +2,8 @@
 
 namespace App\Notifications;
 
-use App\Channels\Messages\DiscordMessage;
-use App\Channels\WebhookChannel;
+use App\Channels\BotChannel;
+use App\Channels\Messages\BotMessage;
 use App\Models\User;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -35,7 +35,7 @@ class MemberRemoved extends Notification implements ShouldQueue
      */
     public function via()
     {
-        return [WebhookChannel::class];
+        return [BotChannel::class];
     }
 
     /**
@@ -44,15 +44,13 @@ class MemberRemoved extends Notification implements ShouldQueue
      *
      * @throws \Exception
      */
-    public function toWebhook($notifiable)
+    public function toBot($notifiable)
     {
-        $channel = $notifiable->settings()->get('officer_channel');
-
         $remover = $this->remover;
 
-        return (new DiscordMessage())
-            ->info()
-            ->to($channel)
+        return (new BotMessage())
+            ->title($notifiable->name.' Division')
+            ->thumbnail(getDivisionIconPath($notifiable->abbreviation))
             ->fields([
                 [
                     'name' => '**MEMBER REMOVED**',
@@ -62,6 +60,7 @@ class MemberRemoved extends Notification implements ShouldQueue
                     'name' => 'View Member Profile',
                     'value' => route('member', $this->member->getUrlParams()),
                 ],
-            ])->send();
+            ])->error()
+            ->send();
     }
 }

--- a/app/Notifications/MemberRequestApproved.php
+++ b/app/Notifications/MemberRequestApproved.php
@@ -2,8 +2,8 @@
 
 namespace App\Notifications;
 
-use App\Channels\Messages\DiscordMessage;
-use App\Channels\WebhookChannel;
+use App\Channels\BotChannel;
+use App\Channels\Messages\BotMessage;
 use App\Models\Member;
 use App\Models\MemberRequest;
 use App\Models\User;
@@ -38,7 +38,7 @@ class MemberRequestApproved extends Notification implements ShouldQueue
      */
     public function via()
     {
-        return [WebhookChannel::class];
+        return [BotChannel::class];
     }
 
     /**
@@ -47,15 +47,12 @@ class MemberRequestApproved extends Notification implements ShouldQueue
      *
      * @throws Exception
      */
-    public function toWebhook($notifiable)
+    public function toBot($notifiable)
     {
-        $channel = $notifiable->settings()->get('officer_channel');
-
-        $message = addslashes("**MEMBER STATUS REQUEST** - :thumbsup: A member status request for `{$this->member->name}` was approved by {$this->approver->name}!");
-
-        return (new DiscordMessage())
-            ->to($channel)
-            ->message($message)
+        return (new BotMessage())
+            ->title($notifiable->name.' Division')
+            ->thumbnail(getDivisionIconPath($notifiable->abbreviation))
+            ->message(addslashes("**MEMBER STATUS REQUEST** - :thumbsup: A member status request for `{$this->member->name}` was approved by {$this->approver->name}!"))
             ->success()
             ->send();
     }

--- a/app/Notifications/MemberRequestDenied.php
+++ b/app/Notifications/MemberRequestDenied.php
@@ -4,8 +4,8 @@
 
 namespace App\Notifications;
 
-use App\Channels\Messages\DiscordMessage;
-use App\Channels\WebhookChannel;
+use App\Channels\BotChannel;
+use App\Channels\Messages\BotMessage;
 use App\Models\Member;
 use App\Models\MemberRequest;
 use Illuminate\Bus\Queueable;
@@ -35,22 +35,20 @@ class MemberRequestDenied extends Notification implements ShouldQueue
      */
     public function via()
     {
-        return [WebhookChannel::class];
+        return [BotChannel::class];
     }
 
     /**
      * @param  mixed  $notifiable
      * @return mixed
      */
-    public function toWebhook($notifiable)
+    public function toBot($notifiable)
     {
-        $channel = $notifiable->settings()->get('officer_channel');
-
         $notes = addslashes($this->request->notes);
 
-        return (new DiscordMessage())
-            ->error()
-            ->to($channel)
+        return (new BotMessage())
+            ->title($notifiable->name.' Division')
+            ->thumbnail(getDivisionIconPath($notifiable->abbreviation))
             ->fields([
                 [
                     'name' => '**MEMBER STATUS REQUEST**',
@@ -64,6 +62,8 @@ class MemberRequestDenied extends Notification implements ShouldQueue
                     'name' => 'Manage member requests',
                     'value' => route('division.member-requests.index', $notifiable),
                 ],
-            ])->send();
+            ])
+            ->success()
+            ->send();
     }
 }

--- a/app/Notifications/MemberRequestHoldLifted.php
+++ b/app/Notifications/MemberRequestHoldLifted.php
@@ -2,8 +2,8 @@
 
 namespace App\Notifications;
 
-use App\Channels\Messages\DiscordMessage;
-use App\Channels\WebhookChannel;
+use App\Channels\BotChannel;
+use App\Channels\Messages\BotMessage;
 use App\Models\Member;
 use App\Models\MemberRequest;
 use Illuminate\Bus\Queueable;
@@ -34,7 +34,7 @@ class MemberRequestHoldLifted extends Notification implements ShouldQueue
      */
     public function via()
     {
-        return [WebhookChannel::class];
+        return [BotChannel::class];
     }
 
     /**
@@ -43,15 +43,12 @@ class MemberRequestHoldLifted extends Notification implements ShouldQueue
      *
      * @throws Exception
      */
-    public function toWebhook($notifiable)
+    public function toBot($notifiable)
     {
-        $channel = $notifiable->settings()->get('officer_channel');
-
-        $message = addslashes("**MEMBER STATUS REQUEST ON HOLD** - :hourglass: The hold placed on `{$this->member->name}` has been lifted. Your request will be processed soon.");
-
-        return (new DiscordMessage())
-            ->to($channel)
-            ->message($message)
+        return (new BotMessage())
+            ->title($notifiable->name.' Division')
+            ->thumbnail(getDivisionIconPath($notifiable->abbreviation))
+            ->message(addslashes("**MEMBER STATUS REQUEST ON HOLD** - :hourglass: The hold placed on `{$this->member->name}` has been lifted. Your request will be processed soon."))
             ->success()
             ->send();
     }

--- a/app/Notifications/MemberRequestPutOnHold.php
+++ b/app/Notifications/MemberRequestPutOnHold.php
@@ -2,8 +2,8 @@
 
 namespace App\Notifications;
 
-use App\Channels\Messages\DiscordMessage;
-use App\Channels\WebhookChannel;
+use App\Channels\BotChannel;
+use App\Channels\Messages\BotMessage;
 use App\Models\Member;
 use App\Models\MemberRequest;
 use App\Models\User;
@@ -36,7 +36,7 @@ class MemberRequestPutOnHold extends Notification implements ShouldQueue
      */
     public function via()
     {
-        return [WebhookChannel::class];
+        return [BotChannel::class];
     }
 
     /**
@@ -45,15 +45,12 @@ class MemberRequestPutOnHold extends Notification implements ShouldQueue
      *
      * @throws Exception
      */
-    public function toWebhook($notifiable)
+    public function toBot($notifiable)
     {
-        $channel = $notifiable->settings()->get('officer_channel');
-
-        $message = addslashes("**MEMBER STATUS REQUEST ON HOLD** - :hourglass: A member status request for `{$this->member->name}` was put on hold by {$this->approver->name} for the following reason: `{$this->request->notes}`");
-
-        return (new DiscordMessage())
-            ->to($channel)
-            ->message($message)
+        return (new BotMessage())
+            ->title($notifiable->name.' Division')
+            ->thumbnail(getDivisionIconPath($notifiable->abbreviation))
+            ->message(addslashes("**MEMBER STATUS REQUEST ON HOLD** - :hourglass: A member status request for `{$this->member->name}` was put on hold by {$this->approver->name} for the following reason: `{$this->request->notes}`"))
             ->success()
             ->send();
     }

--- a/app/Notifications/MemberTransferred.php
+++ b/app/Notifications/MemberTransferred.php
@@ -2,8 +2,9 @@
 
 namespace App\Notifications;
 
+use App\Channels\BotChannel;
+use App\Channels\Messages\BotMessage;
 use App\Channels\Messages\DiscordMessage;
-use App\Channels\WebhookChannel;
 use App\Models\Member;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -31,27 +32,25 @@ class MemberTransferred extends Notification implements ShouldQueue
      */
     public function via()
     {
-        return [WebhookChannel::class];
+        return [BotChannel::class];
     }
 
     /**
-     * @param  mixed  $notifiable
-     * @return array
-     *
+     * @param $notifiable
+     * @return array[]
      * @throws \Exception
      */
-    public function toWebhook($notifiable)
+    public function toBot($notifiable)
     {
-        $channel = $notifiable->settings()->get('officer_channel');
-
-        return (new DiscordMessage())
-            ->info()
-            ->to($channel)
+        return (new BotMessage())
+            ->title($notifiable->name.' Division')
+            ->thumbnail(getDivisionIconPath($notifiable->abbreviation))
             ->fields([
                 [
                     'name' => '**MEMBER TRANSFER**',
                     'value' => addslashes(":recycle: {$this->member->name} [{$this->member->clan_id}] transferred to {$notifiable->name}"),
                 ],
-            ])->send();
+            ])->info()
+            ->send();
     }
 }

--- a/app/Notifications/NewExternalRecruit.php
+++ b/app/Notifications/NewExternalRecruit.php
@@ -2,8 +2,8 @@
 
 namespace App\Notifications;
 
-use App\Channels\Messages\DiscordMessage;
-use App\Channels\WebhookChannel;
+use App\Channels\BotChannel;
+use App\Channels\Messages\BotMessage;
 use App\Models\User;
 use Exception;
 use Illuminate\Bus\Queueable;
@@ -35,7 +35,7 @@ class NewExternalRecruit extends Notification implements ShouldQueue
      */
     public function via()
     {
-        return [WebhookChannel::class];
+        return [BotChannel::class];
     }
 
     /**
@@ -44,26 +44,25 @@ class NewExternalRecruit extends Notification implements ShouldQueue
      *
      * @throws Exception
      */
-    public function toWebhook($notifiable)
+    public function toBot($notifiable)
     {
-        $channel = $notifiable->settings()->get('officer_channel');
-
         $recruiter = $this->recruiter;
 
-        return (new DiscordMessage())
-            ->error()
-            ->to($channel)
+        return (new BotMessage())
+            ->title($notifiable->name.' Division')
+            ->thumbnail(getDivisionIconPath($notifiable->abbreviation))
             ->fields([
                 [
                     'name' => '**EXTERNAL RECRUIT**',
-                    'value' => addslashes("{$recruiter->name} from {$recruiter->member->division->name} just recruited 
-                    `{$this->member->name}` into the {$notifiable->name} Division!"),
+                    'value' => addslashes("{$recruiter->name} from {$recruiter->member->division->name} just recruited " .
+                        "`{$this->member->name}` into the {$notifiable->name} Division!"),
                 ],
                 [
                     'name' => 'View member profile',
                     'value' => route('member', $this->member->getUrlParams()),
                 ],
             ])
+            ->info()
             ->send();
     }
 }

--- a/app/Notifications/NewMemberRecruited.php
+++ b/app/Notifications/NewMemberRecruited.php
@@ -2,8 +2,8 @@
 
 namespace App\Notifications;
 
-use App\Channels\Messages\DiscordMessage;
-use App\Channels\WebhookChannel;
+use App\Channels\BotChannel;
+use App\Channels\Messages\BotMessage;
 use App\Models\User;
 use Exception;
 use Illuminate\Bus\Queueable;
@@ -37,7 +37,7 @@ class NewMemberRecruited extends Notification implements ShouldQueue
      */
     public function via()
     {
-        return [WebhookChannel::class];
+        return [BotChannel::class];
     }
 
     /**
@@ -46,24 +46,24 @@ class NewMemberRecruited extends Notification implements ShouldQueue
      *
      * @throws Exception
      */
-    public function toWebhook($notifiable)
+    public function toBot($notifiable)
     {
-        $channel = $notifiable->settings()->get('officer_channel');
-
         $recruiter = $this->recruiter;
 
-        return (new DiscordMessage())
-            ->success()
-            ->to($channel)
+        return (new BotMessage())
+            ->title($notifiable->name.' Division')
+            ->thumbnail(getDivisionIconPath($notifiable->abbreviation))
             ->fields([
                 [
-                    'name' => '**NEW MEMBER RECRUITED**',
+                    'name' => 'New Member Recruited',
                     'value' => addslashes(':crossed_swords: ' . $recruiter->name . " just recruited `{$this->member->name}` into the {$notifiable->name} Division!"),
                 ],
                 [
                     'name' => 'View Member Profile',
                     'value' => route('member', $this->member->getUrlParams()),
                 ],
-            ])->send();
+            ])
+            ->success()
+            ->send();
     }
 }

--- a/app/Notifications/NotifyAdminTicketCreated.php
+++ b/app/Notifications/NotifyAdminTicketCreated.php
@@ -35,7 +35,6 @@ class NotifyAdminTicketCreated extends Notification implements ShouldQueue
 
         return (new BotMessage())
             ->title('ClanAOD Tracker')
-            ->messageId($notifiable->message_id)
             ->fields([
                 [
                     'name' => "Type: {$notifiable->type->name}",

--- a/app/Notifications/NotifyAdminTicketCreated.php
+++ b/app/Notifications/NotifyAdminTicketCreated.php
@@ -2,8 +2,8 @@
 
 namespace App\Notifications;
 
-use App\Channels\Messages\DiscordMessage;
-use App\Channels\WebhookChannel;
+use App\Channels\BotChannel;
+use App\Channels\Messages\BotMessage;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Notification;
@@ -20,32 +20,32 @@ class NotifyAdminTicketCreated extends Notification implements ShouldQueue
      */
     public function via()
     {
-        return [WebhookChannel::class];
+        return [BotChannel::class];
     }
 
     /**
+     * @param  mixed  $notifiable
      * @return array
      *
-     * @throws \Exception
+     * @throws Exception
      */
-    public function toWebhook($ticket)
+    public function toBot($notifiable)
     {
-        $channel = config('app.aod.admin-ticketing-channel');
+        $authoringUser = $notifiable->caller ? $notifiable->caller->name : 'UNK';
 
-        $authoringUser = $ticket->caller ? $ticket->caller->name : 'UNK';
-
-        return (new DiscordMessage())
-            ->to($channel)
-            ->messageId($ticket->message_id)
-            ->info()
+        return (new BotMessage())
+            ->title('ClanAOD Tracker')
+            ->messageId($notifiable->message_id)
             ->fields([
                 [
-                    'name' => "Type: {$ticket->type->name}",
+                    'name' => "Type: {$notifiable->type->name}",
                     'value' => "Submitted by {$authoringUser}",
                 ], [
                     'name' => 'Link to ticket',
-                    'value' => route('help.tickets.show', $ticket),
+                    'value' => route('help.tickets.show', $notifiable),
                 ],
-            ])->send();
+            ])
+            ->info()
+            ->send();
     }
 }

--- a/app/Notifications/PartTimeMemberRemoved.php
+++ b/app/Notifications/PartTimeMemberRemoved.php
@@ -2,8 +2,8 @@
 
 namespace App\Notifications;
 
-use App\Channels\Messages\DiscordMessage;
-use App\Channels\WebhookChannel;
+use App\Channels\BotChannel;
+use App\Channels\Messages\BotMessage;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Notification;
@@ -34,7 +34,7 @@ class PartTimeMemberRemoved extends Notification implements ShouldQueue
      */
     public function via()
     {
-        return [WebhookChannel::class];
+        return [BotChannel::class];
     }
 
     /**
@@ -42,14 +42,13 @@ class PartTimeMemberRemoved extends Notification implements ShouldQueue
      *
      * @throws \Exception
      */
-    public function toWebhook($notifiable)
+    public function toBot($notifiable)
     {
-        $channel = $notifiable->settings()->get('officer_channel');
         $primaryDivision = $this->member->division;
 
-        return (new DiscordMessage())
-            ->info()
-            ->to($channel)
+        return (new BotMessage())
+            ->title($primaryDivision->name.' Division')
+            ->thumbnail(getDivisionIconPath($primaryDivision->abbreviation))
             ->fields([
                 [
                     'name' => '**PART TIME MEMBER REMOVED**',
@@ -59,6 +58,7 @@ class PartTimeMemberRemoved extends Notification implements ShouldQueue
                     'name' => 'View Member Profile',
                     'value' => route('member', $this->member->getUrlParams()),
                 ],
-            ])->send();
+            ])->error()
+            ->send();
     }
 }

--- a/config/app.php
+++ b/config/app.php
@@ -33,7 +33,7 @@ return [
         'discord_webhook' => env('DISCORD_WEBHOOK'),
         'token' => env('AOD_TOKEN'),
         'discord_bot_token' => env('AOD_BOT_TOKEN'),
-        'bot_api_base_url' => 'https://127.0.0.1:4443/api',
+        'bot_api_base_url' => env('BOT_API_BASE_URL'),
         'maximum_days_inactive' => env('MAX_DAYS_INACTIVE', 90),
         'ingame-reports' => [],
         'api-keys' => [],


### PR DESCRIPTION
This PR converts all of the channel-based messages to BotChannel. DMs and reactions haven't been updated yet.

Please make sure the environment variable, BOT_API_BASE_URL, is defined before deploying since the hard-coded value was removed. 