### PR TITLE
Notify all transfers

### DIFF
--- a/app/AOD/MemberSync/SyncMemberData.php
+++ b/app/AOD/MemberSync/SyncMemberData.php
@@ -130,16 +130,6 @@ class SyncMemberData
 
                 \Log::error($exception->getMessage() . " - Error syncing {$member->name} - {$member->clan_id}");
 
-                // @TODO: figure out why this isn't working
-                (new DiscordMessage())
-                    ->to('admin')
-                    ->message(sprintf('Tracker sync error: %s - Error syncing %s - %d',
-                        $exception->getMessage(),
-                        $member->name,
-                        $member->clan_id,
-                    ))->error()
-                    ->send();
-
                 continue;
             }
 

--- a/app/AOD/MemberSync/SyncMemberData.php
+++ b/app/AOD/MemberSync/SyncMemberData.php
@@ -165,10 +165,16 @@ class SyncMemberData
                         $updates['squad_id'] = 0;
                         $updates['platoon_id'] = 0;
 
-                        // notify division of transfer
+                        // notify new division of transfer
                         $division = Division::find($newData[$key]);
                         if ($division->settings()->get('slack_alert_member_transferred') === 'on') {
-                            $division->notify(new \App\Notifications\MemberTransferred($member, $division));
+                            $division->notify(new \App\Notifications\MemberTransferred($member));
+                        }
+
+                        // notify old division of transfer
+                        $division = Division::find($oldData[$key]);
+                        if ($division->settings()->get('slack_alert_member_transferred') === 'on') {
+                            $division->notify(new \App\Notifications\MemberTransferred($member));
                         }
                     }
 


### PR DESCRIPTION
Originally we only notified the incoming division of a new transfer. This adds a notification to outgoing as well.