### PR TITLE
Reactions tweak

### DIFF
--- a/app/Channels/Messages/BotReactMessage.php
+++ b/app/Channels/Messages/BotReactMessage.php
@@ -29,13 +29,6 @@ class BotReactMessage
         return $this;
     }
 
-    public function messageId(string $messageId)
-    {
-        $this->messageId = $messageId;
-
-        return $this;
-    }
-
     /**
      * @return $this
      */
@@ -66,17 +59,13 @@ class BotReactMessage
             throw new Exception('A status {assigned, resolved, rejected} must be defined');
         }
 
-        if (! $this->messageId) {
-            throw new Exception('A message id must be defined');
-        }
-
         $routeTarget = $this->notifiable->routeNotificationFor('bot');
-        if (! isset($routeTarget) && ! isset($this->target)) {
+        if (! isset($routeTarget)) {
             throw new Exception('A channel target must be defined');
         }
 
         return [
-            'api_uri' => sprintf('channels/%s/messages/%s/react', $routeTarget ?? $this->target, $this->messageId),
+            'api_uri' => sprintf('channels/%s/messages/%s/react', $routeTarget, $this->notifiable->message_id),
             'body' => [
                 'emoji' => $this->emote,
                 'exclusive' => true,

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\CreateTicket;
 use App\Models\Ticket;
 use App\Models\TicketType;
 use App\Models\User;
@@ -93,25 +94,9 @@ class TicketController extends Controller
      *
      * @return Application|Redirector|RedirectResponse|Response
      */
-    public function store(Request $request)
+    public function store(CreateTicket $ticketRequest)
     {
-        $validated = $request->validate([
-            'ticket_type' => 'required',
-            'description' => 'string|min:25|required',
-        ]);
-
-        $ticket = new Ticket();
-        $ticket->state = 'new';
-        $ticket->ticket_type_id = $validated['ticket_type'];
-        $ticket->description = $validated['description'];
-        $ticket->message_id = \Ramsey\Uuid\Uuid::uuid4()->toString();
-        $ticket->caller_id = auth()->id();
-        $ticket->division_id = auth()->user()->member->division_id;
-        $ticket->save();
-
-        // send a message to admin channel as well as to the caller
-        $ticket->notify(new NotifyUserTicketCreated());
-        $ticket->notify(new NotifyAdminTicketCreated());
+        $ticketRequest->persist();
 
         flash('Your ticket has been created! Please allow 24/48 hours for a response from an admin.')->important();
 

--- a/app/Http/Requests/CreateTicket.php
+++ b/app/Http/Requests/CreateTicket.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\Ticket;
+use App\Notifications\NotifyAdminTicketCreated;
+use App\Notifications\NotifyUserTicketCreated;
+use Illuminate\Foundation\Http\FormRequest;
+
+class CreateTicket extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            'ticket_type' => 'required',
+            'description' => 'string|min:25|required',
+        ];
+    }
+
+    public function persist()
+    {
+        $ticket = Ticket::create([
+            'state' => 'new',
+            'ticket_type_id' => $this->validated['ticket_type'],
+            'description' => $this->validated['description'],
+            'caller_id' => auth()->id(),
+            'division_id' => auth()->user()->member->division_id,
+        ]);
+
+        // send a message to admin channel as well as to the caller
+        $ticket->notify(new NotifyUserTicketCreated());
+        $ticket->notify(new NotifyAdminTicketCreated());
+    }
+}

--- a/app/Notifications/TicketReaction.php
+++ b/app/Notifications/TicketReaction.php
@@ -41,7 +41,6 @@ class TicketReaction extends Notification implements ShouldQueue
     public function toBot($notifiable)
     {
         return (new BotReactMessage($notifiable))
-            ->messageId($notifiable->message_id)
             ->status($this->status)
             ->send();
     }


### PR DESCRIPTION
This moves ticket persistence to a request object. It also removes the default message id since we no longer need to inform the bot of a generic UUID, we get one when the message is posted as well as a minor refactor to refer to the message id from the notifiable rather than setting it separately in the notification