### PR TITLE
Use nullsafe operator when displaying platoons on voice report

### DIFF
--- a/resources/views/division/reports/voice-report.blade.php
+++ b/resources/views/division/reports/voice-report.blade.php
@@ -56,7 +56,7 @@
                             </a>
                         </td>
                         <td>
-                            {{ $member->platoon->name }}
+                            {{ $member->platoon?->name }}
                         </td>
                         <td>
                             {{ $member->discord }}


### PR DESCRIPTION
An error is thrown when a member without an assigned platoon is displayed on the voice report due to a property read attempt on a null Platoon object. 

This will happen for the CO, XO, General Sgt, Clan Admin positions, and an unassigned member after a division transfer or assignment reset. 