### PR TITLE
Member activity formatting improvements

### DIFF
--- a/app/Models/Helpers.php
+++ b/app/Models/Helpers.php
@@ -2,6 +2,7 @@
 
 use App\Models\MemberRequest;
 use App\Settings\UserSettings;
+use Carbon\Carbon;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Arr;
 
@@ -202,7 +203,7 @@ function checked($arg)
 
 function carbon_date_or_null_if_zero($value)
 {
-    return ($value === null || Carbon::parse($value)->timestamp <= 0) ? null : $value;
+    return ($value === null || str_contains($value, '1970-01-01') || Carbon::parse($value)->timestamp <= 0) ? null : $value;
 }
 
 /**
@@ -229,6 +230,21 @@ function getActivityClass($date, $division)
     }
 
     return 'text-success';
+}
+
+/**
+ * Provides visual feedback for a member's last activity
+ * for display on their member profile
+ *
+ * @return string
+ */
+function getMemberProfileActivityClass($date)
+{
+    if (! $date instanceof \Carbon\Carbon) {
+        return 'text-muted';
+    } else {
+        return '';
+    }
 }
 
 /**

--- a/app/Models/Member/HasCustomAttributes.php
+++ b/app/Models/Member/HasCustomAttributes.php
@@ -22,6 +22,13 @@ trait HasCustomAttributes
         );
     }
 
+    public function voiceInvalid(): Attribute
+    {
+        return new Attribute(
+            fn ($value, $attributes) => carbon_date_or_null_if_zero($attributes['last_voice_activity']) === null
+        );
+    }
+
     public function lastPromoted(): Attribute
     {
         return new Attribute(

--- a/app/Presenters/MemberPresenter.php
+++ b/app/Presenters/MemberPresenter.php
@@ -35,7 +35,7 @@ class MemberPresenter extends Presenter
             'last_ts_activity',
             'last_voice_activity',
         ])) {
-            throw new \Exception('Invalid activity type provided to `getActivity()`');
+            throw new \Exception('Invalid activity type provided to `lastActive()`');
         }
 
         $value = $this->member->$activityType;

--- a/resources/views/member/partials/general-information.blade.php
+++ b/resources/views/member/partials/general-information.blade.php
@@ -11,15 +11,8 @@
                 <div class="row m-t-xs">
                     <div class="col-md-3 col-xs-12 text-center">
                         <h2 class="no-margins">
-                            @if ($member->isPending)
-                                <span class="text-muted">UNAVAILABLE</span>
-                            @elseif ($member->tsInvalid)
-                                --
-                            @else
-                                {{ Carbon::parse($member->last_ts_activity)->diffInDays() }}
-                                {{ \Illuminate\Support\Str::plural('day',
-                            $member->last_ts_activity->diffInDays()) }}
-                            @endif
+                            <span title="{{ $member->last_ts_activity }}"
+                                  class="{{  getMemberProfileActivityClass($member->last_ts_activity) }}">{{ $member->present()->lastActive('last_ts_activity', ['weeks','months']) }}</span>
                         </h2>
                         Since last <span class="c-white">TS activity</span>
                     </div>
@@ -40,14 +33,8 @@
 
                     <div class="col-md-3 col-xs-12 text-center">
                         <h2 class="no-margins">
-                            @if ($member->last_voice_activity)
-                                {{ Carbon::parse($member->last_voice_activity)->diffInDays() }}
-                                {{ \Illuminate\Support\Str::plural('day',
-                            $member->last_voice_activity->diffInDays()) }}
-                            @else
-                                --
-                            @endif
-
+                            <span title="{{ $member->last_voice_activity }}"
+                                  class="{{  getMemberProfileActivityClass($member->last_voice_activity) }}">{{ $member->present()->lastActive('last_voice_activity', ['weeks','months']) }}</span>
                         </h2>
                         Since Last <span class="c-white">Discord Voice Activity</span>
                     </div>

--- a/resources/views/member/partials/member-data-row.blade.php
+++ b/resources/views/member/partials/member-data-row.blade.php
@@ -26,13 +26,10 @@
                     </span>
     </td>
     <td class="text-center">
-        @if ($member->tsInvalid)
-            <span class="text-danger">MISCONFIGURATION</span>
-        @else
-            <span class="{{ getActivityClass(Carbon::parse($member->last_ts_activity), $division) }}">
-                {{ $member->present()->lastActive('last_ts_activity') }}
-            </span>
-        @endif
+                    <span class="{{ getActivityClass($member->last_ts_activity, $division) }}"
+                          title="{{$member->last_ts_activity}}">
+                        {{ $member->present()->lastActive('last_ts_activity') }}
+                    </span>
     </td>
     <td class="col-hidden">{{ $member->last_ts_activity }}</td>
     <td class="text-center">{{ $member->last_promoted_at ?? 'Never' }}</td>


### PR DESCRIPTION
Updates member activity display on profile and division member lists to represent their status better.

Notable changes:
- Fixes the epoch bug - these and other invalid dates will display as "Never"
- Display a "Pending" status while a member request is pending approval
- Consolidates most of the logic into presenters and helper functions and reduces some duplication in the views.

I had some timezone issues in my local environment so we'll need to see if the epoch check works properly on dev. 