### PR TITLE
Move icon logic for to division-heading componet

### DIFF
--- a/resources/views/activity/show.blade.php
+++ b/resources/views/activity/show.blade.php
@@ -2,12 +2,7 @@
 
 @section('content')
 
-    @component ('application.components.division-heading', [$division])
-        @slot ('icon')
-            <a href="{{ route('division', $division->slug) }}">
-                <img src="{{ getDivisionIconPath($division->abbreviation) }}" />
-            </a>
-        @endslot
+    @component ('application.components.division-heading', ['division' => $division])
         @slot ('heading')
             {{ $division->name }} Division
         @endslot

--- a/resources/views/application/components/division-heading.blade.php
+++ b/resources/views/application/components/division-heading.blade.php
@@ -1,6 +1,11 @@
 <div class="division-header">
     <div class="header-icon">
-        {{ $icon }}
+        @if ($division)
+            <img src="{{ getDivisionIconPath($division->abbreviation) }}"
+                 class="division-icon-large"/>
+        @else
+            <img src="{{ asset('images/logo_v2.svg') }}" class="division-icon-large"/>
+        @endif
     </div>
     <div class="header-title">
         <h3 class="m-b-xs">

--- a/resources/views/division/create-pm.blade.php
+++ b/resources/views/division/create-pm.blade.php
@@ -2,10 +2,7 @@
 
 @section('content')
 
-    @component ('application.components.division-heading', [$division])
-        @slot ('icon')
-            <img src="{{ getDivisionIconPath($division->abbreviation) }}" class="division-icon-large"/>
-        @endslot
+    @component ('application.components.division-heading', ['division' => $division])
         @slot ('heading')
             {{ $division->name }}
         @endslot

--- a/resources/views/division/inactive-members.blade.php
+++ b/resources/views/division/inactive-members.blade.php
@@ -2,10 +2,7 @@
 
 @section('content')
 
-    @component ('application.components.division-heading', [$division])
-        @slot ('icon')
-            <img src="{{ getDivisionIconPath($division->abbreviation) }}" class="division-icon-large"/>
-        @endslot
+    @component ('application.components.division-heading', ['division' => $division])
         @slot ('heading')
             {{ $division->name }}
         @endslot

--- a/resources/views/division/members.blade.php
+++ b/resources/views/division/members.blade.php
@@ -2,10 +2,7 @@
 
 @section('content')
 
-    @component ('application.components.division-heading', [$division])
-        @slot ('icon')
-            <img src="{{ getDivisionIconPath($division->abbreviation) }}" class="division-icon-large"/>
-        @endslot
+    @component ('application.components.division-heading', ['division' => $division])
         @slot ('heading')
             <span class="hidden-xs">{{ $division->name }}</span>
         @endslot

--- a/resources/views/division/modify.blade.php
+++ b/resources/views/division/modify.blade.php
@@ -2,10 +2,7 @@
 
 @section('content')
 
-    @component ('application.components.division-heading')
-        @slot ('icon')
-            <img src="{{ getDivisionIconPath($division->abbreviation) }}" class="division-icon-large" />
-        @endslot
+    @component ('application.components.division-heading', ['division' => $division])
         @slot ('heading')
             {{ $division->name }} Division
         @endslot

--- a/resources/views/division/notes.blade.php
+++ b/resources/views/division/notes.blade.php
@@ -2,10 +2,7 @@
 
 @section('content')
 
-    @component ('application.components.division-heading', [$division])
-        @slot ('icon')
-            <img src="{{ getDivisionIconPath($division->abbreviation) }}" class="division-icon-large" />
-        @endslot
+    @component ('application.components.division-heading', ['division' => $division])
         @slot ('heading')
             <span class="hidden-xs">{{ $division->name }}</span>
             <span class="visible-xs">{{ $division->abbreviation }}</span>

--- a/resources/views/division/part-time.blade.php
+++ b/resources/views/division/part-time.blade.php
@@ -2,10 +2,7 @@
 
 @section('content')
 
-    @component ('application.components.division-heading', [$division])
-        @slot ('icon')
-            <img src="{{ getDivisionIconPath($division->abbreviation) }}" class="division-icon-large"/>
-        @endslot
+    @component ('application.components.division-heading', ['division' => $division])
         @slot ('heading')
             Part-Timers
         @endslot

--- a/resources/views/division/reports/census.blade.php
+++ b/resources/views/division/reports/census.blade.php
@@ -2,10 +2,7 @@
 
 @section('content')
 
-    @component ('application.components.division-heading')
-        @slot ('icon')
-            <img src="{{ getDivisionIconPath($division->abbreviation) }}" class="division-icon-large" />
-        @endslot
+    @component ('application.components.division-heading', ['division' => $division])
         @slot ('heading')
             Census Data
         @endslot

--- a/resources/views/division/reports/ingame-report.blade.php
+++ b/resources/views/division/reports/ingame-report.blade.php
@@ -2,10 +2,7 @@
 
 @section('content')
 
-    @component ('application.components.division-heading')
-        @slot ('icon')
-            <img src="{{ getDivisionIconPath($division->abbreviation) }}" class="division-icon-large" />
-        @endslot
+    @component ('application.components.division-heading', ['division' => $division])
         @slot ('heading')
             Ingame Reporting
         @endslot

--- a/resources/views/division/reports/promotions.blade.php
+++ b/resources/views/division/reports/promotions.blade.php
@@ -2,10 +2,7 @@
 
 @section('content')
 
-    @component ('application.components.division-heading', [$division])
-        @slot ('icon')
-            <img src="{{ getDivisionIconPath($division->abbreviation) }}" class="division-icon-large" />
-        @endslot
+    @component ('application.components.division-heading', ['division' => $division])
         @slot ('heading')
             <span class="hidden-xs">Promotions Report</span>
             <span class="visible-xs">Promotions</span>

--- a/resources/views/division/reports/retention-report.blade.php
+++ b/resources/views/division/reports/retention-report.blade.php
@@ -2,10 +2,7 @@
 
 @section('content')
 
-    @component ('application.components.division-heading')
-        @slot ('icon')
-            <img src="{{ getDivisionIconPath($division->abbreviation) }}" class="division-icon-large"/>
-        @endslot
+    @component ('application.components.division-heading', ['division' => $division])
         @slot ('heading')
             Member Retention
         @endslot

--- a/resources/views/division/reports/voice-report.blade.php
+++ b/resources/views/division/reports/voice-report.blade.php
@@ -2,10 +2,7 @@
 
 @section('content')
 
-    @component ('application.components.division-heading')
-        @slot ('icon')
-            <img src="{{ getDivisionIconPath($division->abbreviation) }}" class="division-icon-large"/>
-        @endslot
+    @component ('application.components.division-heading', ['division' => $division])
         @slot ('heading')
             Voice Comms Issues
         @endslot

--- a/resources/views/division/show.blade.php
+++ b/resources/views/division/show.blade.php
@@ -2,10 +2,7 @@
 
 @section('content')
 
-    @component ('application.components.division-heading', [$division])
-        @slot ('icon')
-            <img src="{{ getDivisionIconPath($division->abbreviation) }}" class="division-icon-large" />
-        @endslot
+    @component ('application.components.division-heading', ['division' => $division])
         @slot ('heading')
             <span class="hidden-xs">{{ $division->name }}</span>
             <span class="visible-xs">{{ $division->abbreviation }}</span>

--- a/resources/views/division/structure-editor.blade.php
+++ b/resources/views/division/structure-editor.blade.php
@@ -6,10 +6,7 @@
 
 @section('content')
 
-    @component ('application.components.division-heading', [$division])
-        @slot ('icon')
-            <img src="{{ getDivisionIconPath($division->abbreviation) }}" class="division-icon-large" />
-        @endslot
+    @component ('application.components.division-heading', ['division' => $division])
         @slot ('heading')
             <span class="hidden-xs">{{ $division->name }}</span>
             <span class="visible-xs">{{ $division->abbreviation }}</span>

--- a/resources/views/division/structure.blade.php
+++ b/resources/views/division/structure.blade.php
@@ -2,10 +2,7 @@
 
 @section('content')
 
-    @component ('application.components.division-heading', [$division])
-        @slot ('icon')
-            <img src="{{ getDivisionIconPath($division->abbreviation) }}" class="division-icon-large"/>
-        @endslot
+    @component ('application.components.division-heading', ['division' => $division])
         @slot ('heading')
             <span class="hidden-xs">Division Structure</span>
             <span class="visible-xs">Structure</span>

--- a/resources/views/leave/edit.blade.php
+++ b/resources/views/leave/edit.blade.php
@@ -2,15 +2,7 @@
 
 @section('content')
 
-    @component ('application.components.division-heading')
-        @slot ('icon')
-            @if ($division)
-                <img src="{{ getDivisionIconPath($division->abbreviation) }}"
-                     class="division-icon-large"/>
-            @else
-                <img src="{{ asset('images/logo_v2.svg') }}" width="50px" style="opacity: .2;"/>
-            @endif
-        @endslot
+    @component ('application.components.division-heading', ['division' => $division])
         @slot ('heading')
             {!! $member->present()->rankName !!}
             @include('member.partials.member-actions-button', ['member' => $member])

--- a/resources/views/leave/index.blade.php
+++ b/resources/views/leave/index.blade.php
@@ -2,10 +2,7 @@
 
 @section('content')
 
-    @component ('application.components.division-heading', [$division])
-        @slot ('icon')
-            <img src="{{ getDivisionIconPath($division->abbreviation) }}" class="division-icon-large" />
-        @endslot
+    @component ('application.components.division-heading', ['division' => $division])
         @slot ('heading')
             <span class="hidden-xs">Leaves of Absence</span>
             <span class="visible-xs">Leave</span>

--- a/resources/views/member/confirm-unassign.blade.php
+++ b/resources/views/member/confirm-unassign.blade.php
@@ -2,15 +2,7 @@
 
 @section('content')
 
-    @component ('application.components.division-heading')
-        @slot ('icon')
-            @if ($division)
-                <img src="{{ getDivisionIconPath($division->abbreviation) }}"
-                     class="division-icon-large" />
-            @else
-                <img src="{{ asset('images/logo_v2.svg') }}" width="50px" style="opacity: .2;" />
-            @endif
-        @endslot
+    @component ('application.components.division-heading', ['division' => $division])
         @slot ('heading')
             {!! $member->present()->rankName !!}
         @endslot

--- a/resources/views/member/edit-member.blade.php
+++ b/resources/views/member/edit-member.blade.php
@@ -1,14 +1,7 @@
 @extends('application.base-tracker')
 @section('content')
 
-    @component ('application.components.division-heading')
-        @slot ('icon')
-            @if ($division)
-                <img src="{{ getDivisionIconPath($division->abbreviation) }}" />
-            @else
-                <img class="division-icon-large" src="{{ asset('images/logo_v2.svg') }}" />
-            @endif
-        @endslot
+    @component ('application.components.division-heading', ['division' => $division])
         @slot ('heading')
             {!! $member->present()->rankName !!}
         @endslot

--- a/resources/views/member/edit-note.blade.php
+++ b/resources/views/member/edit-note.blade.php
@@ -2,15 +2,7 @@
 
 @section('content')
 
-    @component ('application.components.division-heading')
-        @slot ('icon')
-            @if ($division)
-                <img src="{{ getDivisionIconPath($division->abbreviation) }}"
-                     class="division-icon-large" />
-            @else
-                <img src="{{ asset('images/logo_v2.svg') }}" width="50px" style="opacity: .2;" />
-            @endif
-        @endslot
+    @component ('application.components.division-heading', ['division' => $division])
         @slot ('heading')
             {!! $member->present()->rankName !!}
             @include('member.partials.member-actions-button', ['member' => $member])

--- a/resources/views/member/forms/recruiter.blade.php
+++ b/resources/views/member/forms/recruiter.blade.php
@@ -1,7 +1,7 @@
 <div class="division-header">
     <div class="header-icon">
         @if ($member->recruiter)
-            <img src="{{ getDivisionIconPath($division->abbreviation) }}" />
+            <img src="{{ getDivisionIconPath($division->abbreviation) }}" class="division-icon-large"/>
         @else
             <img src="{{ asset('images/logo_v2.svg') }}" width="50px" style="opacity: .2;" />
         @endif

--- a/resources/views/member/manage-ingame-handles.blade.php
+++ b/resources/views/member/manage-ingame-handles.blade.php
@@ -1,14 +1,7 @@
 @extends('application.base-tracker')
 @section('content')
 
-    @component ('application.components.division-heading')
-        @slot ('icon')
-            @if ($division)
-                <img src="{{ getDivisionIconPath($division->abbreviation) }}" class="division-icon-large" />
-            @else
-                <img src="{{ asset('images/logo_v2.svg') }}" width="50px" style="opacity: .2;" />
-            @endif
-        @endslot
+    @component ('application.components.division-heading', ['division' => $division])
         @slot ('heading')
             {!! $member->present()->rankName !!}
         @endslot

--- a/resources/views/member/manage-part-time.blade.php
+++ b/resources/views/member/manage-part-time.blade.php
@@ -1,14 +1,7 @@
 @extends('application.base-tracker')
 @section('content')
 
-    @component ('application.components.division-heading')
-        @slot ('icon')
-            @if ($division)
-                <img src="{{ getDivisionIconPath($division->abbreviation) }}" class="division-icon-large"  />
-            @else
-                <img src="{{ asset('images/logo_v2.svg') }}" class="division-icon-large" style="opacity: .2;" />
-            @endif
-        @endslot
+    @component ('application.components.division-heading', ['division' => $division])
         @slot ('heading')
             {!! $member->present()->rankName !!}
         @endslot

--- a/resources/views/member/show.blade.php
+++ b/resources/views/member/show.blade.php
@@ -2,15 +2,7 @@
 
 @section('content')
 
-    @component ('application.components.division-heading')
-        @slot ('icon')
-            @if ($division)
-                <img src="{{ getDivisionIconPath($division->abbreviation) }}"
-                     class="division-icon-large"/>
-            @else
-                <img src="{{ asset('images/logo_v2.svg') }}" width="50px" style="opacity: .2;"/>
-            @endif
-        @endslot
+    @component ('application.components.division-heading', ['division' => $division])
         @slot ('heading')
             {!! $member->present()->rankName !!}
             @include('member.partials.member-actions-button', ['member' => $member])

--- a/resources/views/platoon/create.blade.php
+++ b/resources/views/platoon/create.blade.php
@@ -1,12 +1,7 @@
 @extends('application.base-tracker')
 @section('content')
 
-    @component ('application.components.division-heading')
-        @slot ('icon')
-            <a href="{{ route('division', $division->slug) }}">
-                <img src="{{ getDivisionIconPath($division->abbreviation) }}" />
-            </a>
-        @endslot
+    @component ('application.components.division-heading', ['division' => $division])
         @slot ('heading')
             {{ $division->name }} Division
         @endslot

--- a/resources/views/platoon/edit.blade.php
+++ b/resources/views/platoon/edit.blade.php
@@ -1,12 +1,7 @@
 @extends('application.base-tracker')
 @section('content')
 
-    @component ('application.components.division-heading')
-        @slot ('icon')
-            <a href="{{ route('division', $division->slug) }}">
-                <img src="{{ getDivisionIconPath($division->abbreviation) }}" />
-            </a>
-        @endslot
+    @component ('application.components.division-heading', ['division' => $division])
         @slot ('heading')
             {{ $division->name }} Division
         @endslot

--- a/resources/views/platoon/manage-members.blade.php
+++ b/resources/views/platoon/manage-members.blade.php
@@ -2,12 +2,7 @@
 
 @section('content')
 
-    @component ('application.components.division-heading')
-        @slot ('icon')
-            <a href="{{ route('division', $division->slug) }}">
-                <img src="{{ getDivisionIconPath($division->abbreviation) }}" class="division-icon-large" />
-            </a>
-        @endslot
+    @component ('application.components.division-heading', ['division' => $division])
         @slot ('heading')
             {{ $platoon->name }}
         @endslot

--- a/resources/views/platoon/show.blade.php
+++ b/resources/views/platoon/show.blade.php
@@ -1,12 +1,7 @@
 @extends('application.base-tracker')
 @section('content')
 
-    @component ('application.components.division-heading')
-        @slot ('icon')
-            <a href="{{ route('division', $division->slug) }}">
-                <img src="{{ getDivisionIconPath($division->abbreviation) }}" class="division-icon-large"/>
-            </a>
-        @endslot
+    @component ('application.components.division-heading', ['division' => $division])
         @slot ('heading')
             {{ $platoon->name ?? "Untitled " . $division->locality('platoon') }}
             @include('platoon.partials.edit-platoon-button', ['division' => $division])

--- a/resources/views/recruit/form.blade.php
+++ b/resources/views/recruit/form.blade.php
@@ -2,10 +2,7 @@
 
 @section('content')
 
-    @component ('application.components.division-heading', [$division])
-        @slot ('icon')
-            <img src="{{ getDivisionIconPath($division->abbreviation) }}" class="division-icon-large" />
-        @endslot
+    @component ('application.components.division-heading', ['division' => $division])
         @slot ('heading')
             Add New Recruit
         @endslot

--- a/resources/views/squad/create.blade.php
+++ b/resources/views/squad/create.blade.php
@@ -1,10 +1,7 @@
 @extends('application.base-tracker')
 @section('content')
 
-    @component ('application.components.division-heading')
-        @slot ('icon')
-            <img src="{{ getDivisionIconPath($division->abbreviation) }}" class="division-icon-large" />
-        @endslot
+    @component ('application.components.division-heading', ['division' => $division])
         @slot ('heading')
             {{ $division->name }} Division
         @endslot

--- a/resources/views/squad/edit.blade.php
+++ b/resources/views/squad/edit.blade.php
@@ -1,15 +1,7 @@
 @extends('application.base-tracker')
 @section('content')
 
-    @component ('application.components.division-heading')
-        @slot ('icon')
-            @if ($division)
-                <img src="{{ getDivisionIconPath($division->abbreviation) }}"
-                     class="division-icon-large" />
-            @else
-                <img src="{{ asset('images/logo_v2.svg') }}" width="50px" style="opacity: .2;" />
-            @endif
-        @endslot
+    @component ('application.components.division-heading', ['division' => $division])
         @slot ('heading')
             {{ $squad->name }}
         @endslot

--- a/resources/views/squad/show.blade.php
+++ b/resources/views/squad/show.blade.php
@@ -1,12 +1,7 @@
 @extends('application.base-tracker')
 @section('content')
 
-    @component ('application.components.division-heading')
-        @slot ('icon')
-            <a href="{{ route('division', $division->slug) }}">
-                <img src="{{ getDivisionIconPath($division->abbreviation) }}" class="division-icon-large" />
-            </a>
-        @endslot
+    @component ('application.components.division-heading', ['division' => $division])
         @slot ('heading')
             {{ $squad->name ?? "Untitled " . $division->locality('squad') }}
             @include('squad.partials.edit-squad-button', ['division' => $division])


### PR DESCRIPTION
Moves the logic for retrieving and formatting the division icon on most division-related pages to the existing `division-heading` component. 

This standardizes formatting and resolves #329 on the member edit and several other pages. 