### PR TITLE
Fix activity status again

### DIFF
--- a/app/Models/Helpers.php
+++ b/app/Models/Helpers.php
@@ -203,7 +203,7 @@ function checked($arg)
 
 function carbon_date_or_null_if_zero($value)
 {
-    return ($value === null || str_contains($value, '1970-01-01') || Carbon::parse($value)->timestamp <= 0) ? null : $value;
+    return ($value === null || Carbon::parse($value)->timestamp <= 0) ? null : $value;
 }
 
 /**

--- a/app/Presenters/MemberPresenter.php
+++ b/app/Presenters/MemberPresenter.php
@@ -50,9 +50,9 @@ class MemberPresenter extends Presenter
             ? $value
             : \Carbon\Carbon::parse($value);
 
-        $epochStart = Carbon::createFromTimestampUTC(0);
+        $epochStart = Carbon::createFromTimestamp(0);
 
-        if ($epochStart->equalTo($value->shiftTimezone('UTC'))) {
+        if ($epochStart->equalTo($value)) {
             return 'Never';
         }
 


### PR DESCRIPTION
Revert some of the previous activity status changes since times provided through forum sync are stored in local time, not UTC. 