### PR TITLE
Only show notification if division settings actually change

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -19,6 +19,11 @@ class Controller extends BaseController
         Toastr::success($message, $title);
     }
 
+    protected function showInfoToast($message, $title = 'Info')
+    {
+        Toastr::info($message, $title);
+    }
+
     protected function showErrorToast($message, $title = 'Uh oh...')
     {
         Toastr::error($message, $title, [

--- a/app/Http/Controllers/DivisionController.php
+++ b/app/Http/Controllers/DivisionController.php
@@ -107,9 +107,15 @@ class DivisionController extends Controller
     public function update(UpdateDivision $form, Division $division)
     {
         $form->persist();
-        $this->showSuccessToast('Changes saved successfully');
+
+        if (! $division->wasChanged('settings')) {
+            $this->showInfoToast('No changes were made');
+            return back();
+        }
+
         $division->recordActivity('updated_settings');
 
+        $this->showSuccessToast('Changes saved successfully');
         if ($division->settings()->get('slack_alert_division_edited')) {
             $division->notify(new \App\Notifications\DivisionEdited($division, auth()->user()->name));
         }


### PR DESCRIPTION
Disable Discord notification when editing division settings if no actual changes were made. (closes #298)