### PR TITLE
Hotfix for division structure undefined bug

### DIFF
--- a/app/Http/Controllers/DivisionStructureController.php
+++ b/app/Http/Controllers/DivisionStructureController.php
@@ -39,6 +39,8 @@ class DivisionStructureController extends Controller
     {
         $this->authorize('viewDivisionStructure', auth()->user());
 
+        $data = null;
+
         try {
             $compiledData = $this->compileDivisionData($division);
 

--- a/app/Http/Controllers/DivisionStructureController.php
+++ b/app/Http/Controllers/DivisionStructureController.php
@@ -66,7 +66,7 @@ class DivisionStructureController extends Controller
 
             $data = $env->render('structure', ['division' => $compiledData]);
         } catch (\Exception $error) {
-            $data = $this->handleTwigError($error);
+            $this->handleTwigError($error);
         }
 
         return view('division.structure', compact('data', 'division'));
@@ -259,13 +259,17 @@ class DivisionStructureController extends Controller
     private function handleTwigError($error)
     {
         if ($error instanceof Twig_Error_Syntax) {
-            return $error->getMessage();
+            $this->showErrorToast($error->getMessage());
+
+            return;
         }
 
         if ($error instanceof Twig_Sandbox_SecurityError) {
-            return 'You attempted to use an unauthorized tag, filter, or method';
+            $this->showErrorToast('You attempted to use an unauthorized tag, filter, or method');
+
+            return;
         }
 
-        return $error->getMessage();
+        $this->showErrorToast($error->getMessage());
     }
 }

--- a/app/Http/Controllers/DivisionStructureController.php
+++ b/app/Http/Controllers/DivisionStructureController.php
@@ -12,7 +12,6 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Redirector;
 use Illuminate\View\View;
 use stdClass;
-use Twig_Error;
 use Twig_Error_Syntax;
 use Twig_Sandbox_SecurityError;
 
@@ -66,7 +65,7 @@ class DivisionStructureController extends Controller
             }));
 
             $data = $env->render('structure', ['division' => $compiledData]);
-        } catch (Twig_Error $error) {
+        } catch (\Exception $error) {
             $data = $this->handleTwigError($error);
         }
 

--- a/app/Nova/Division.php
+++ b/app/Nova/Division.php
@@ -76,6 +76,8 @@ class Division extends Resource
             Code::make('Settings')
                 ->json(),
 
+            Code::make('Structure'),
+
             Date::make('Created At')->sortable(),
 
             Date::make('Updated At')->sortable(),


### PR DESCRIPTION
- Expands the exception handling to include all exceptions, which fixes `500` errors from taking over when no structure is defined, which happens when new divisions are created
- Reports compilation errors as toast messages instead of outputing to the editor textarea
- Adds division structure edit field to the Nova Division model

Fixes #335 

