### PR TITLE
Handle discord in flagged inactives

### DIFF
--- a/resources/views/division/inactive-members.blade.php
+++ b/resources/views/division/inactive-members.blade.php
@@ -54,21 +54,6 @@
             </div>
         </div>
 
-        @if ($flaggedMembers->count() > 0)
-            <div class="panel panel-filled">
-                <div class="panel-heading">Share Flagged Members ({{ count($flaggedMembers) }})</div>
-                <div class="panel-body">
-                    <pre name="bb-code-flagged" id="bb-code-flagged"
-                         style="max-height: 100px; overflow-y: scroll">[list]@foreach ($flaggedMembers as $member)
-                            [*][profile={{ $member->clan_id }}]{{ $member->present()->rankName }}[/profile] -
-                            Seen {{ $member->last_activity->diffInDays() }} days ago @endforeach[/list]</pre>
-                    <button data-clipboard-target="#bb-code-flagged" class="copy-to-clipboard btn-success btn"><i
-                                class="fa fa-clone"></i> Copy BB-Code
-                    </button>
-                </div>
-            </div>
-        @endif
-
         @include('division.partials.inactivity-log')
     </div>
 

--- a/resources/views/division/partials/flagged-members.blade.php
+++ b/resources/views/division/partials/flagged-members.blade.php
@@ -3,11 +3,9 @@
         <thead>
         <tr>
             <th>Member</th>
-            <th>Last Forum Activity
-                <small class="slight">Days</small>
-            </th>
-            <th>Last TS Activity
-                <small class="slight">Days</small>
+            <th>
+                {{ $inactivityMetric === 'last_voice_activity' ? 'Last Discord Voice Activity' : 'Last TS Activity' }}
+                <small class="text-muted">Days</small></th>
             </th>
             <th class="no-sort"></th>
             <th class="no-sort"></th>
@@ -22,13 +20,14 @@
                     <span class="text-muted slight">{{ $member->rank->abbreviation }}</span>
                 </td>
                 <td>
-                    <code>{{ $member->last_activity->diffInDays() }}</code>
-                </td>
-                <td>
-                    @if ($member->tsInvalid)
-                        <code title="Misconfiguration"><span class="text-danger">00000</span></code>
-                    @else
-                        <code>{!! Carbon::parse($member->last_ts_activity)->diffInDays() !!}</code>
+                    @if ($inactivityMetric === 'last_ts_activity')
+                        @if ($member->tsInvalid)
+                            <code title="Misconfiguration"><span class="text-danger">00000</span></code>
+                        @else
+                            <code>{!! Carbon::parse($member->last_ts_activity)->diffInDays() !!}</code>
+                        @endif
+                    @elseif($inactivityMetric === 'last_voice_activity')
+                        <code>{{ $member->last_voice_activity->diffInDays() }}</code>
                     @endif
                 </td>
                 <td>


### PR DESCRIPTION
Fixes #327

Also drops the bb-code section since that didn't appear to get much use. Folks wanting to share the information can just link to that particular page on the tracker