### PR TITLE
Division logos

### DIFF
--- a/app/Filament/Resources/DivisionResource.php
+++ b/app/Filament/Resources/DivisionResource.php
@@ -3,8 +3,14 @@
 namespace App\Filament\Resources;
 
 use App\Filament\Resources\DivisionResource\Pages;
+use App\Filament\Resources\DivisionResource\RelationManagers\DivisionsRelationManager;
 use App\Models\Division;
 use Filament\Forms;
+use Filament\Forms\Components\Section;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
@@ -23,35 +29,71 @@ class DivisionResource extends Resource
     {
         return $form
             ->schema([
-                Forms\Components\TextInput::make('name')
-                    ->required()
-                    ->maxLength(255),
-                Forms\Components\TextInput::make('handle_id')
-                    ->required()
-                    ->numeric(),
-                Forms\Components\TextInput::make('officer_role_id')
-                    ->numeric()
-                    ->required(),
-                Forms\Components\TextInput::make('forum_app_id')
-                    ->required()
-                    ->numeric(),
-                Forms\Components\TextInput::make('abbreviation')
-                    ->required()
-                    ->maxLength(255),
-                Forms\Components\TextInput::make('description')
-                    ->required()
-                    ->maxLength(255),
-                Forms\Components\Toggle::make('active')
-                    ->default(true),
-                FilamentJsonColumn::make('settings')
-                    ->accent('#f6a821')
-                    ->required()
-                    ->columnSpanFull(),
-                Forms\Components\Textarea::make('structure')
-                    ->hidden()
-                    ->default('[]')
-                    ->columnSpanFull(),
-                Forms\Components\DateTimePicker::make('shutdown_at'),
+                Section::make('Tracker Details')
+                    ->schema([
+                        Forms\Components\FileUpload::make('logo')
+                            ->label('Logo (48x48)')
+                            ->hint(str('[Icon Extraction Tool >](https://jarlpenguin.github.io/BeCyIconGrabberPortable/)')->inlineMarkdown()->toHtmlString())
+                            ->required()
+                            ->alignCenter()
+                            ->avatar()
+                            ->directory('logos'),
+
+                        Select::make('handle_id')
+                            ->label('Game Handle')
+                            ->relationship('handle', 'label'),
+
+                        TextInput::make('name')
+                            ->required()
+                            ->maxLength(255),
+
+                        TextInput::make('abbreviation')
+                            ->hint('Should match abbreviation used on forums')
+                            ->maxLength(3)
+                            ->required()
+                            ->maxLength(255),
+
+                        TextInput::make('description')
+                            ->default('Another AOD Division')
+                            ->hint('Deprecated and soon to be removed')
+                            ->maxLength(255),
+                    ]),
+
+                Section::make('Forum Details')
+                    ->description('Division must already have been created in the forums in order to populate these values')
+                    ->schema([
+                        TextInput::make('officer_role_id')
+                            ->hint(str('[View Forum Usergroups](https://www.clanaod.net/forums/admincp/usergroup.php?do=modify)')
+                                ->inlineMarkdown()->toHtmlString())
+                            ->numeric()
+                            ->required(),
+                        TextInput::make('forum_app_id')
+                            ->label('Application form id')
+                            ->hint(
+                                str('[View Division Forms](https://www.clanaod.net/forums/forms.php)')
+                                    ->inlineMarkdown()
+                                    ->toHtmlString()
+                            )
+                            ->required()
+                            ->numeric(),
+                    ]),
+
+                Forms\Components\Split::make([
+                    Section::make([
+
+                        Forms\Components\DateTimePicker::make('shutdown_at')->columns(3)
+
+                    ])->columnSpan(6),
+                    Section::make([
+
+                        Toggle::make('active')
+                            ->label('Division Enabled')
+                            ->hint('Disabled divisions are not listed on the tracker or website')
+                            ->default(true),
+                    ])->columnSpan(6)
+                ])->from('lg')->columnSpanFull()
+
+
             ]);
     }
 
@@ -59,40 +101,16 @@ class DivisionResource extends Resource
     {
         return $table
             ->columns([
+                Tables\Columns\ImageColumn::make('logo'),
                 Tables\Columns\TextColumn::make('name')
-                    ->searchable(),
+                    ->searchable()
+                    ->sortable(),
                 Tables\Columns\TextColumn::make('slug')
                     ->searchable(),
-                Tables\Columns\TextColumn::make('handle_id')
-                    ->numeric()
-                    ->sortable(),
-                Tables\Columns\TextColumn::make('officer_role_id')
-                    ->numeric()
-                    ->sortable(),
-                Tables\Columns\TextColumn::make('forum_app_id')
-                    ->numeric()
-                    ->sortable(),
                 Tables\Columns\TextColumn::make('abbreviation')
-                    ->searchable(),
-                Tables\Columns\TextColumn::make('description')
                     ->searchable(),
                 Tables\Columns\IconColumn::make('active')
                     ->boolean(),
-                Tables\Columns\TextColumn::make('created_at')
-                    ->dateTime()
-                    ->sortable()
-                    ->toggleable(isToggledHiddenByDefault: true),
-                Tables\Columns\TextColumn::make('updated_at')
-                    ->dateTime()
-                    ->sortable()
-                    ->toggleable(isToggledHiddenByDefault: true),
-                Tables\Columns\TextColumn::make('shutdown_at')
-                    ->dateTime()
-                    ->sortable(),
-                Tables\Columns\TextColumn::make('deleted_at')
-                    ->dateTime()
-                    ->sortable()
-                    ->toggleable(isToggledHiddenByDefault: true),
             ])
             ->filters([
                 //
@@ -110,7 +128,6 @@ class DivisionResource extends Resource
     public static function getRelations(): array
     {
         return [
-            //
         ];
     }
 

--- a/app/Models/Division.php
+++ b/app/Models/Division.php
@@ -90,9 +90,7 @@ class Division extends Model
     /**
      * @var array
      */
-    protected $fillable = [
-        'settings', 'name', 'handle_id', 'forum_app_id', 'description', 'active', 'abbreviation', 'shutdown_at',
-    ];
+    protected $guarded = [];
 
     public static function boot()
     {

--- a/database/migrations/2019_12_14_000001_add_expiration_to_personal_access_tokens_table.php
+++ b/database/migrations/2019_12_14_000001_add_expiration_to_personal_access_tokens_table.php
@@ -11,9 +11,11 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('personal_access_tokens', function (Blueprint $table) {
-            $table->timestamp('expires_at')->nullable();
-        });
+        if (! Schema::hasColumn('personal_access_tokens', 'expires_at')) {
+            Schema::table('personal_access_tokens', function (Blueprint $table) {
+                $table->timestamp('expires_at')->nullable();
+            });
+        }
     }
 
     /**
@@ -21,8 +23,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('personal_access_tokens', function (Blueprint $table) {
-            $table->dropColumn('expires_at');
-        });
+        //
     }
 };

--- a/database/migrations/2024_07_22_155600_add_logo_column_to_divisions_table.php
+++ b/database/migrations/2024_07_22_155600_add_logo_column_to_divisions_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('divisions', function (Blueprint $table) {
+            $table->string('logo')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('divisions', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/public/storage
+++ b/public/storage
@@ -1,0 +1,1 @@
+/var/www/html/storage/app/public

--- a/resources/views/leave/edit.blade.php
+++ b/resources/views/leave/edit.blade.php
@@ -63,7 +63,7 @@
         </div>
 
         <div class="m-t-xl">
-            <form action="{{ route('leave.update', [$member->clan_id]) }}">
+            <form action="{{ route('leave.update', [$member->clan_id]) }}" method="post">
                 <input type="hidden" value="{{ $leave->id }}" name="leave_id"/>
                 <input type="hidden" name="requester_id" value="{{ $leave->requester->id }}"/>
                 @include('leave.forms.edit-leave')
@@ -91,7 +91,9 @@
         </div>
 
         <div class="m-t-xl">
-            <form action="{{ route('leave.delete', [$member->clan_id, $leave->id]) }}">
+            <form action="{{ route('leave.delete', [$member->clan_id, $leave->id]) }}" method="post">
+                @csrf
+                @method('delete')
                 @include('leave.forms.delete-leave')
             </form>
         </div>

--- a/resources/views/leave/forms/create-leave.blade.php
+++ b/resources/views/leave/forms/create-leave.blade.php
@@ -13,7 +13,7 @@
         </div>
         <div class="form-group">
             <label for="note_thread_id">Forum Thread Id</label>
-            <input type="number" name="note_thread_id" id="note_thread_id" class="form-control"">
+            <input type="number" name="note_thread_id" id="note_thread_id" class="form-control">
         </div>
     </div>
     <div class="col-md-8">
@@ -22,12 +22,12 @@
             <div class="col-xs-6">
                 <div class="form-group {{ $errors->has('member_id') ? ' has-error' : null }}">
                     <label for="member_id">Member Id</label><span class="text-accent">*</span>
-                    <input type="number" class="form-control" required="required">
+                    <input type="number" class="form-control" required="required" id="member_id" name="member_id">
                 </div>
             </div>
             <div class="col-xs-6">
                 <label for="leave_type">Leave Type</label><span class="text-accent">*</span>
-                <select name="reason" id="reason" class="form-control">
+                <select name="leave_type" id="leave_type" class="form-control">
                     @foreach (config('app.aod.leave_reasons') as $reason)
                         <option value="{{ strtolower($reason) }}">{{ $reason }}</option>
                     @endforeach
@@ -36,7 +36,8 @@
         </div>
 
         <label for="note_body">Justification</label> <span class="text-accent">*</span>
-        <textarea name="note_body" id="note_body" rows="5" style="resize:vertical" required="required"></textarea>
+        <textarea name="note_body" id="note_body" rows="5" style="resize:vertical" required="required"
+                  class="form-control"></textarea>
     </div>
 </div>
 <button class="btn btn-success pull-right m-t-sm form-group" type="submit">Submit</button>

--- a/resources/views/leave/forms/delete-leave.blade.php
+++ b/resources/views/leave/forms/delete-leave.blade.php
@@ -12,5 +12,3 @@
         <button type="submit" class="btn btn-danger">Revoke LOA</button>
     </div>
 </div>
-
-@csrf

--- a/resources/views/leave/forms/edit-leave.blade.php
+++ b/resources/views/leave/forms/edit-leave.blade.php
@@ -1,5 +1,6 @@
 @include('application.partials.errors')
 @method('patch')
+@csrf
 <div class="row">
     <div class="col-xs-6">
         <div class="form-group {{ $errors->has('end_date') ? ' has-error' : null }}">


### PR DESCRIPTION
- Allows for upload of the division logo at the point of creation (or later)
- Cleans up overall fields
- Removes the need to keep division logos in version control for either the tracker or the site - these can be cleaned up later once we've migrated them over
- Fixes a few various forms missing CSRF and method field