### PR TITLE
Various hotfixes, division resource filter

### DIFF
--- a/app/Filament/Resources/DivisionResource.php
+++ b/app/Filament/Resources/DivisionResource.php
@@ -3,19 +3,18 @@
 namespace App\Filament\Resources;
 
 use App\Filament\Resources\DivisionResource\Pages;
-use App\Filament\Resources\DivisionResource\RelationManagers\DivisionsRelationManager;
 use App\Models\Division;
 use Filament\Forms;
 use Filament\Forms\Components\Section;
 use Filament\Forms\Components\Select;
-use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
+use Filament\Tables\Filters\Filter;
 use Filament\Tables\Table;
-use ValentinMorice\FilamentJsonColumn\FilamentJsonColumn;
+use Illuminate\Database\Eloquent\Builder;
 
 class DivisionResource extends Resource
 {
@@ -81,7 +80,7 @@ class DivisionResource extends Resource
                 Forms\Components\Split::make([
                     Section::make([
 
-                        Forms\Components\DateTimePicker::make('shutdown_at')->columns(3)
+                        Forms\Components\DateTimePicker::make('shutdown_at')->columns(3),
 
                     ])->columnSpan(6),
                     Section::make([
@@ -90,9 +89,8 @@ class DivisionResource extends Resource
                             ->label('Division Enabled')
                             ->hint('Disabled divisions are not listed on the tracker or website')
                             ->default(true),
-                    ])->columnSpan(6)
-                ])->from('lg')->columnSpanFull()
-
+                    ])->columnSpan(6),
+                ])->from('lg')->columnSpanFull(),
 
             ]);
     }
@@ -113,7 +111,10 @@ class DivisionResource extends Resource
                     ->boolean(),
             ])
             ->filters([
-                //
+                Filter::make('is_active')
+                    ->query(fn (Builder $query): Builder => $query->where('active', true))
+                    ->label('Hide inactive')
+                    ->default(),
             ])
             ->actions([
                 Tables\Actions\EditAction::make(),

--- a/app/Models/Activity.php
+++ b/app/Models/Activity.php
@@ -7,7 +7,7 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 class Activity extends Model
 {
-    protected $fillable = ['subject_id', 'subject_type', 'name', 'division_id', 'user_id'];
+    protected $guarded = [];
 
     protected $with = [
         'user',

--- a/app/Models/Census.php
+++ b/app/Models/Census.php
@@ -11,6 +11,8 @@ class Census extends Model
     use HasCustomAttributes;
     use HasFactory;
 
+    protected $guarded = [];
+
     public function division()
     {
         return $this->belongsTo(Division::class);

--- a/app/Models/Division.php
+++ b/app/Models/Division.php
@@ -416,9 +416,4 @@ class Division extends Model
             }
         }
     }
-
-    public function setSlugAttribute($value)
-    {
-        $this->attributes['slug'] = Str::slug($this->name);
-    }
 }

--- a/app/Models/Handle.php
+++ b/app/Models/Handle.php
@@ -15,12 +15,7 @@ class Handle extends Model
         'visible' => 'boolean',
     ];
 
-    protected $fillable = [
-        'label',
-        'type',
-        'comment',
-        'url',
-    ];
+    protected $guarded = [];
 
     public function divisions()
     {

--- a/app/Models/Rank.php
+++ b/app/Models/Rank.php
@@ -10,10 +10,9 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
  */
 class Rank extends Model
 {
-    /**
-     * @return BelongsToMany
-     */
-    public function members()
+    protected $guarded = [];
+
+    public function members(): BelongsToMany
     {
         return $this->hasMany(Member::class);
     }

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -7,15 +7,14 @@ use Illuminate\Database\Eloquent\Model;
 
 class Role extends Model
 {
-    public function present()
+    protected $guarded = [];
+
+    public function present(): RolePresenter
     {
         return new RolePresenter($this);
     }
 
-    /**
-     * relationship - role belongs to many users.
-     */
-    public function users()
+    public function users(): \Illuminate\Database\Eloquent\Relations\HasMany
     {
         return $this->hasMany(User::class);
     }

--- a/resources/views/leave/forms/create-leave.blade.php
+++ b/resources/views/leave/forms/create-leave.blade.php
@@ -9,7 +9,8 @@
         </div>
         <div class="form-group {{ $errors->has('end_date') ? ' has-error' : null }}">
             <label for="end_date">Leave End Date</label><span class="text-accent">*</span>
-            <input type="date" class="form-control" required="required" placeholder="mm/dd/yyyy">
+            <input type="date" class="form-control" required="required"
+                   placeholder="mm/dd/yyyy" id="end_date" name="end_date">
         </div>
         <div class="form-group">
             <label for="note_thread_id">Forum Thread Id</label>


### PR DESCRIPTION
- Drops fillable properties for guarded for models only modifiable from Filament
- Get rid of pointless slug setter (I blame lack of sleep)
- LOA create form `end_date` wasn't properly identified 
- Adds a filament filter for active division, and makes it the default