### PR TITLE
Logo path revamp

### DIFF
--- a/app/Models/Bot/Commands/Division.php
+++ b/app/Models/Bot/Commands/Division.php
@@ -39,7 +39,7 @@ class Division extends Base implements Command
                     'color' => 10181046,
                     'author' => [
                         'name' => $division->name,
-                        'icon_url' => getDivisionIconPath($division->abbreviation),
+                        'icon_url' => $division->getLogoPath(),
                         'url' => 'https://clanaod.net/divisions/' . \Str::slug($division->name),
                     ],
                     'fields' => [

--- a/app/Models/Division.php
+++ b/app/Models/Division.php
@@ -393,10 +393,10 @@ class Division extends Model
     public function getLogoPath()
     {
         if ($this->logo) {
-            return Storage::url($this->logo);
+            return asset(Storage::url($this->logo));
         }
 
-        return asset('/images/logo_v2.svg');
+        return asset('images/logo_v2.svg');
     }
 
     public function isShutdown()

--- a/app/Models/Division.php
+++ b/app/Models/Division.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 
 /**
@@ -142,7 +143,7 @@ class Division extends Model
 
         $invalidStates = array_diff($state, $validStates);
 
-        if (! empty($invalidStates)) {
+        if (!empty($invalidStates)) {
             throw new \InvalidArgumentException(sprintf(
                 'Invalid Discord state: %s',
                 implode(', ', $invalidStates)
@@ -331,7 +332,7 @@ class Division extends Model
     public function locality($string)
     {
         $locality = collect($this->settings()->locality);
-        if (! $locality->count()) {
+        if (!$locality->count()) {
             Log::error("No locality defaults were found for division {$this->name}");
 
             return ucwords($string);
@@ -341,7 +342,7 @@ class Division extends Model
                 return $translation['old-string'] === strtolower($string);
             }
         });
-        if (! $results) {
+        if (!$results) {
             Log::error("The {$string} locality does not exist");
 
             return ucwords($string);
@@ -387,6 +388,15 @@ class Division extends Model
     public function isActive()
     {
         return $this->active;
+    }
+
+    public function getLogoPath()
+    {
+        if ($this->logo) {
+            return Storage::url($this->logo);
+        }
+
+        return asset('/images/logo_v2.svg');
     }
 
     public function isShutdown()

--- a/app/Models/Helpers.php
+++ b/app/Models/Helpers.php
@@ -151,15 +151,6 @@ function hasDivisionIcon($abbreviation)
     return File::exists($image);
 }
 
-function getDivisionIconPath($abbreviation)
-{
-    if (hasDivisionIcon($abbreviation)) {
-        return asset("/images/game_icons/48x48/{$abbreviation}.png");
-    }
-
-    return asset('/images/logo_v2.svg');
-}
-
 /**
  * array_keys with recursive implementation.
  *

--- a/app/Notifications/DivisionEdited.php
+++ b/app/Notifications/DivisionEdited.php
@@ -35,7 +35,7 @@ class DivisionEdited extends Notification implements ShouldQueue
     {
         return (new BotChannelMessage($notifiable))
             ->title($notifiable->name . ' Division')
-            ->thumbnail(getDivisionIconPath($notifiable->abbreviation))
+            ->thumbnail($notifiable->getLogoPath())
             ->message(sprintf('%s updated the division settings', $this->user))
             ->info()
             ->send();

--- a/app/Notifications/MemberNameChanged.php
+++ b/app/Notifications/MemberNameChanged.php
@@ -35,7 +35,7 @@ class MemberNameChanged extends Notification implements ShouldQueue
     {
         return (new BotChannelMessage($notifiable))
             ->title($notifiable->name . ' Division')
-            ->thumbnail(getDivisionIconPath($notifiable->abbreviation))
+            ->thumbnail($notifiable->getLogoPath())
             ->message(addslashes(":tools: **MEMBER STATUS - NAME CHANGE**\n`{$this->names['oldName']}` is now known as `{$this->names['newName']}`. Please inform the member of this change."))
             ->success()
             ->send();

--- a/app/Notifications/MemberRemoved.php
+++ b/app/Notifications/MemberRemoved.php
@@ -53,7 +53,7 @@ class MemberRemoved extends Notification implements ShouldQueue
 
         return (new BotChannelMessage($notifiable))
             ->title($notifiable->name . ' Division')
-            ->thumbnail(getDivisionIconPath($notifiable->abbreviation))->fields([
+            ->thumbnail($notifiable->getLogoPath())->fields([
                 [
                     'name' => 'Member Removed',
                     'value' => sprintf(

--- a/app/Notifications/MemberRequestApproved.php
+++ b/app/Notifications/MemberRequestApproved.php
@@ -53,7 +53,7 @@ class MemberRequestApproved extends Notification implements ShouldQueue
     {
         return (new BotChannelMessage($notifiable))
             ->title($notifiable->name . ' Division')
-            ->thumbnail(getDivisionIconPath($notifiable->abbreviation))
+            ->thumbnail($notifiable->getLogoPath())
             ->message(addslashes("**MEMBER STATUS REQUEST** - :thumbsup: A member status request for `{$this->member->name}` was approved by {$this->approver->name}!"))
             ->success()
             ->send();

--- a/app/Notifications/MemberRequestDenied.php
+++ b/app/Notifications/MemberRequestDenied.php
@@ -49,7 +49,7 @@ class MemberRequestDenied extends Notification implements ShouldQueue
 
         return (new BotChannelMessage($notifiable))
             ->title($notifiable->name . ' Division')
-            ->thumbnail(getDivisionIconPath($notifiable->abbreviation))
+            ->thumbnail($notifiable->getLogoPath())
             ->fields([
                 [
                     'name' => '**MEMBER STATUS REQUEST**',

--- a/app/Notifications/MemberRequestHoldLifted.php
+++ b/app/Notifications/MemberRequestHoldLifted.php
@@ -48,7 +48,7 @@ class MemberRequestHoldLifted extends Notification implements ShouldQueue
     {
         return (new BotChannelMessage($notifiable))
             ->title($notifiable->name . ' Division')
-            ->thumbnail(getDivisionIconPath($notifiable->abbreviation))
+            ->thumbnail($notifiable->getLogoPath())
             ->message(addslashes("**MEMBER STATUS REQUEST ON HOLD** - :hourglass: The hold placed on `{$this->member->name}` has been lifted. Your request will be processed soon."))
             ->success()
             ->send();

--- a/app/Notifications/MemberRequestPutOnHold.php
+++ b/app/Notifications/MemberRequestPutOnHold.php
@@ -51,7 +51,7 @@ class MemberRequestPutOnHold extends Notification implements ShouldQueue
     {
         return (new BotChannelMessage($notifiable))
             ->title($notifiable->name . ' Division')
-            ->thumbnail(getDivisionIconPath($notifiable->abbreviation))
+            ->thumbnail($notifiable->getLogoPath())
             ->message(addslashes("**MEMBER STATUS REQUEST ON HOLD** - :hourglass: A member status request for `{$this->member->name}` was put on hold by {$this->approver->name} for the following reason: `{$this->request->notes}`"))
             ->success()
             ->send();

--- a/app/Notifications/MemberTransferred.php
+++ b/app/Notifications/MemberTransferred.php
@@ -47,7 +47,7 @@ class MemberTransferred extends Notification implements ShouldQueue
     {
         return (new BotChannelMessage($notifiable))
             ->title($this->destinationDivision->name . ' Division')
-            ->thumbnail(getDivisionIconPath($this->destinationDivision->abbreviation))
+            ->thumbnail($this->destinationDivision->getLogoPath())
             ->fields([
                 [
                     'name' => '**MEMBER TRANSFER**',

--- a/app/Notifications/NewExternalRecruit.php
+++ b/app/Notifications/NewExternalRecruit.php
@@ -50,7 +50,7 @@ class NewExternalRecruit extends Notification implements ShouldQueue
 
         return (new BotChannelMessage($notifiable))
             ->title($notifiable->name . ' Division')
-            ->thumbnail(getDivisionIconPath($notifiable->abbreviation))
+            ->thumbnail($notifiable->getLogoPath())
             ->fields([
                 [
                     'name' => ':crossed_swords: New Member Recruited (External)',

--- a/app/Notifications/NewMemberRecruited.php
+++ b/app/Notifications/NewMemberRecruited.php
@@ -52,7 +52,7 @@ class NewMemberRecruited extends Notification implements ShouldQueue
 
         return (new BotChannelMessage($notifiable))
             ->title($notifiable->name . ' Division')
-            ->thumbnail(getDivisionIconPath($notifiable->abbreviation))
+            ->thumbnail($notifiable->getLogoPath())
             ->fields([
                 [
                     'name' => ':crossed_swords: New Member Recruited',

--- a/app/Notifications/PartTimeMemberRemoved.php
+++ b/app/Notifications/PartTimeMemberRemoved.php
@@ -52,7 +52,7 @@ class PartTimeMemberRemoved extends Notification implements ShouldQueue
     {
         return (new BotChannelMessage($notifiable))
             ->title($this->primaryDivision->name . ' Division')
-            ->thumbnail(getDivisionIconPath($this->primaryDivision->abbreviation))
+            ->thumbnail($this->primaryDivision->getLogoPath())
             ->fields([
                 [
                     'name' => '**PART TIME MEMBER REMOVED**',

--- a/app/Transformers/DivisionBasicTransformer.php
+++ b/app/Transformers/DivisionBasicTransformer.php
@@ -14,7 +14,7 @@ class DivisionBasicTransformer extends Transformer
             'forum_app_id' => $item->forum_app_id,
             'members_count' => $item->members_count,
             'officer_channel' => $item->settings()->get('officer_channel'),
-            'icon' => getDivisionIconPath($item->abbreviation),
+            'icon' => $item->getLogoPath(),
         ];
     }
 }

--- a/resources/views/application/components/division-heading.blade.php
+++ b/resources/views/application/components/division-heading.blade.php
@@ -1,7 +1,7 @@
 <div class="division-header">
     <div class="header-icon">
         @if ($division)
-            <img src="{{ getDivisionIconPath($division->abbreviation) }}"
+            <img src="{{ $division->getLogoPath() }}"
                  class="division-icon-large"/>
         @else
             <img src="{{ asset('images/logo_v2.svg') }}" class="division-icon-large"/>

--- a/resources/views/home/partials/divisions.blade.php
+++ b/resources/views/home/partials/divisions.blade.php
@@ -5,7 +5,7 @@
            class="panel panel-filled division-header {{ ($division->isShutdown()) ? 'panel-c-danger' : null }}">
             <div class="panel-body">
                 <h4 class="m-b-none text-uppercase m-t-sm">
-                    <img src="{{ getDivisionIconPath($division->abbreviation) }}"
+                    <img src="{{ $division->getLogoPath() }}"
                          class="pull-right division-icon-medium"/>
                     @if ($division->isShutDown())
                         <strike title="Division is shut down">{{ $division->name }}</strike>

--- a/resources/views/leave/forms/edit-leave.blade.php
+++ b/resources/views/leave/forms/edit-leave.blade.php
@@ -5,7 +5,8 @@
     <div class="col-xs-6">
         <div class="form-group {{ $errors->has('end_date') ? ' has-error' : null }}">
             <label for="end_date">Leave End Date</label><span class="text-accent">*</span>
-            <input type="date" value="{{ $leave->end_date->format('Y-m-d') }}" placeholder="mm/dd/yyyy" class="form-control">
+            <input type="date" value="{{ $leave->end_date->format('Y-m-d') }}" name="end_date" id="end_date"
+                   placeholder="mm/dd/yyyy" class="form-control">
         </div>
     </div>
 
@@ -26,7 +27,7 @@
     <div class="col-md-6">
         @if (! $leave->approver)
             <div class="form-group">
-                <input type="checkbox" id="approve_leave" name="approve_leave" /> <label
+                <input type="checkbox" id="approve_leave" name="approve_leave"/> <label
                         for="approve_leave">Approve leave of absence?</label>
             </div>
         @endif

--- a/resources/views/member/forms/recruiter.blade.php
+++ b/resources/views/member/forms/recruiter.blade.php
@@ -1,7 +1,7 @@
 <div class="division-header">
     <div class="header-icon">
         @if ($member->recruiter)
-            <img src="{{ getDivisionIconPath($division->abbreviation) }}" class="division-icon-large"/>
+            <img src="{{ $division->getLogoPath() }}" class="division-icon-large"/>
         @else
             <img src="{{ asset('images/logo_v2.svg') }}" width="50px" style="opacity: .2;" />
         @endif

--- a/resources/views/member/partials/part-time-divisions.blade.php
+++ b/resources/views/member/partials/part-time-divisions.blade.php
@@ -16,7 +16,7 @@
                     <h4 class="text-uppercase">
                         {{ $division->name }}
                         <span class="pull-right">
-                            <img src="{{ getDivisionIconPath($division->abbreviation) }}"
+                            <img src="{{ $division->getLogoPath() }}"
                                  class="division-icon-medium"
                                  title="{{ $division->name }}" />
                         </span>

--- a/resources/views/recruit/index.blade.php
+++ b/resources/views/recruit/index.blade.php
@@ -30,7 +30,7 @@
                     <a href="{{ route('recruiting.form', [$division->slug]) }}" class="panel panel-filled">
                         <div class="panel-body">
                             <h4>
-                                <img src="{{ getDivisionIconPath($division->abbreviation) }}"
+                                <img src="{{ $division->getLogoPath() }}"
                                      class="division-icon-medium" />
                                 {{ $division->name }}
                             </h4>

--- a/resources/views/reports/leadership.blade.php
+++ b/resources/views/reports/leadership.blade.php
@@ -52,7 +52,7 @@
 
                 @foreach ($divisions as $division)
                     <h4 id="{{ $division->abbreviation }}">
-                        <img src="{{ getDivisionIconPath($division->abbreviation) }}" class="division-icon-medium"/>
+                        <img src="{{ $division->getLogoPath() }}" class="division-icon-medium"/>
                         {{ $division->name }}
                         <span class="badge" title="Sgts and SSgts">{{ $division->sgt_and_ssgt_count }} Sgts*</span>
                         <span class="badge">{{ $division->members_count }} Members</span>


### PR DESCRIPTION
- Replaces the error-prone method of looking up division icons and instead uses the uploaded logo
- Hotfix for LOA creation