### PR TITLE
Improve message id naming

### DIFF
--- a/app/Channels/BotChannel.php
+++ b/app/Channels/BotChannel.php
@@ -55,7 +55,7 @@ class BotChannel
             if ($notification instanceof NotifyAdminTicketCreated) {
                 // we need the resulting message id for additional actions
                 $response = json_decode($response->getBody());
-                $notifiable->update(['message_id' => $response->id]);
+                $notifiable->update(['external_message_id' => $response->id]);
             }
 
         } catch (ServerException $exception) {

--- a/app/Channels/Messages/BotReactMessage.php
+++ b/app/Channels/Messages/BotReactMessage.php
@@ -63,7 +63,7 @@ class BotReactMessage
         }
 
         return [
-            'api_uri' => sprintf('channels/%s/messages/%s/react', $routeTarget, $this->notifiable->message_id),
+            'api_uri' => sprintf('channels/%s/messages/%s/react', $routeTarget, $this->notifiable->external_message_id),
             'body' => [
                 'emoji' => $this->emote,
                 'exclusive' => true,

--- a/app/Filament/Resources/TicketResource.php
+++ b/app/Filament/Resources/TicketResource.php
@@ -28,8 +28,8 @@ class TicketResource extends Resource
                     ->required()
                     ->numeric()
                     ->default(1),
-                Forms\Components\TextInput::make('message_id')
-                    ->required()
+                Forms\Components\TextInput::make('external_message_id')
+                    ->readOnly()
                     ->maxLength(36),
                 Forms\Components\Textarea::make('description')
                     ->required()

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -124,7 +124,7 @@ class TicketController extends Controller
 
         $ticket->notify(new NotifyCallerTicketUpdated(':white_check_mark: ' . $message));
 
-        if ($ticket->message_id) {
+        if ($ticket->hasExternalMessageId()) {
             $ticket->notify(new TicketReaction('resolved'));
         }
 
@@ -144,7 +144,7 @@ class TicketController extends Controller
 
         $ticket->notify(new NotifyCallerTicketUpdated($message));
 
-        if ($ticket->message_id) {
+        if ($ticket->hasExternalMessageId()) {
             // reopened tickets are assigned to the current admin
             $ticket->notify(new TicketReaction('assigned'));
         }
@@ -164,7 +164,7 @@ class TicketController extends Controller
 
         $ticket->notify(new NotifyCallerTicketUpdated($message));
 
-        if ($ticket->message_id) {
+        if ($ticket->hasExternalMessageId()) {
             $ticket->notify(new TicketReaction('rejected'));
         }
 
@@ -188,7 +188,7 @@ class TicketController extends Controller
         $ticket->notify(new NotifyCallerTicketUpdated($message));
         $ticket->notify(new NotifyNewTicketOwner($assignedUser, auth()->user()));
 
-        if ($ticket->message_id) {
+        if ($ticket->hasExternalMessageId()) {
             $ticket->notify(new TicketReaction('assigned'));
         }
 
@@ -207,7 +207,7 @@ class TicketController extends Controller
 
         $ticket->notify(new NotifyCallerTicketUpdated($message));
 
-        if ($ticket->message_id) {
+        if ($ticket->hasExternalMessageId()) {
             $ticket->notify(new TicketReaction('assigned'));
         }
 

--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -162,6 +162,6 @@ class Ticket extends Model
 
     public function hasExternalMessageId(): bool
     {
-        return (bool) $this->external_message_id;
+        return ! empty($this->external_message_id);
     }
 }

--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -159,4 +159,9 @@ class Ticket extends Model
             'body' => $comment,
         ]);
     }
+
+    public function hasExternalMessageId(): bool
+    {
+        return (bool) $this->external_message_id;
+    }
 }

--- a/database/migrations/2024_08_02_165416_rename_message_id_column_on_tickets_table.php
+++ b/database/migrations/2024_08_02_165416_rename_message_id_column_on_tickets_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('tickets', function (Blueprint $table) {
+            $table->renameColumn('message_id', 'external_message_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('tickets', function (Blueprint $table) {
+            $table->renameColumn('external_message_id', 'message_id');
+        });
+    }
+};


### PR DESCRIPTION
Ticket message id field is ambiguous so I've renamed it to make explicitly clear that it is external. Also replaced references to the field with a boolean since they are only checking that the field is set

Also updates the filament resource to make it read only