### PR TITLE
Division structure documentation update

### DIFF
--- a/resources/views/help/partials/member-properties.blade.php
+++ b/resources/views/help/partials/member-properties.blade.php
@@ -28,7 +28,7 @@
         <td><code>integer</code></td>
     </tr>
     <tr>
-        <td><code>member.position.name</code></td>
+        <td><code>member.position.getLabel()</code></td>
         <td>position currently held by member</td>
         <td><code>string</code></td>
     </tr>


### PR DESCRIPTION
Update division structure documentation to use `.getLabel()` rather than `.name`.