### PR TITLE
Add AODClient and Discord Member Sync

### DIFF
--- a/app/Http/Controllers/RecruitingController.php
+++ b/app/Http/Controllers/RecruitingController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Enums\Position;
+use App\Jobs\SyncDiscordMember;
 use App\Models\Division;
 use App\Models\Member;
 use App\Models\MemberRequest;
@@ -59,6 +60,9 @@ class RecruitingController extends Controller
         if ($division->settings()->get('slack_alert_created_member') === 'on') {
             $this->handleNotification($request, $member, $division);
         }
+
+        // create job to sync discord member
+        SyncDiscordMember::dispatch($member);
 
         $this->showSuccessToast('Your recruitment has successfully been completed!');
     }

--- a/app/Jobs/SyncDiscordMember.php
+++ b/app/Jobs/SyncDiscordMember.php
@@ -15,9 +15,7 @@ class SyncDiscordMember implements ShouldQueue
     /**
      * Create a new job instance.
      */
-    public function __construct(public Member $member)
-    {
-    }
+    public function __construct(public Member $member) {}
 
     /**
      * Execute the job.
@@ -33,7 +31,7 @@ class SyncDiscordMember implements ShouldQueue
             return;
         }
 
-        if (!empty($botAPIResponse->discordid)) {
+        if (! empty($botAPIResponse->discordid)) {
             $this->member->discord_id = $botAPIResponse->discordid;
 
             try {
@@ -43,7 +41,7 @@ class SyncDiscordMember implements ShouldQueue
             }
         }
 
-        if (!empty($botAPIResponse->discordtag)) {
+        if (! empty($botAPIResponse->discordtag)) {
             $this->member->discord = $botAPIResponse->discordtag;
         }
 

--- a/app/Jobs/SyncDiscordMember.php
+++ b/app/Jobs/SyncDiscordMember.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Member;
+use App\Services\AODClient;
+use GuzzleHttp\Exception\GuzzleException;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class SyncDiscordMember implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(public Member $member) {}
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        $botAPIResponse = $this->member->forumMember();
+
+        if (! empty($botAPIResponse->discordid)) {
+            $this->member->discord_id = $botAPIResponse->discordid;
+
+            try {
+                (new AODClient)->updateDiscordMember($this->member->discord_id);
+            } catch (GuzzleException $exception) {
+                \Log::error($exception->getMessage());
+            }
+        }
+
+        if (! empty($botAPIResponse->discordtag)) {
+            $this->member->discord = $botAPIResponse->discordtag;
+        }
+
+        $this->member->save();
+    }
+}

--- a/app/Models/Member.php
+++ b/app/Models/Member.php
@@ -6,7 +6,6 @@ use App\Activities\RecordsActivity;
 use App\Enums\Position;
 use App\Models\Member\HasCustomAttributes;
 use App\Presenters\MemberPresenter;
-use App\Services\AODClient;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -341,22 +340,5 @@ class Member extends Model
                 . PHP_EOL
                 . implode(PHP_EOL, $properties),
         ];
-    }
-
-    /**
-     * Returns the member's forum information via the bot API. Null is returned if the member is not found.
-     * 
-     * @return object|null
-     */
-    public function forumMember()
-    {
-        try {
-            $response = (new AODClient)->getForumMember($this->clan_id);
-            $response = json_decode($response->getBody());
-
-            return $response[0];
-        } catch (\Exception $e) {
-            return null;
-        }
     }
 }

--- a/app/Models/Member.php
+++ b/app/Models/Member.php
@@ -6,6 +6,7 @@ use App\Activities\RecordsActivity;
 use App\Enums\Position;
 use App\Models\Member\HasCustomAttributes;
 use App\Presenters\MemberPresenter;
+use App\Services\AODClient;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -340,5 +341,22 @@ class Member extends Model
                 . PHP_EOL
                 . implode(PHP_EOL, $properties),
         ];
+    }
+
+    /**
+     * Returns the member's forum information via the bot API. Null is returned if the member is not found.
+     * 
+     * @return object|null
+     */
+    public function forumMember()
+    {
+        try {
+            $response = (new AODClient)->getForumMember($this->clan_id);
+            $response = json_decode($response->getBody());
+
+            return $response[0];
+        } catch (\Exception $e) {
+            return null;
+        }
     }
 }

--- a/app/Services/AODClient.php
+++ b/app/Services/AODClient.php
@@ -36,6 +36,11 @@ class AODClient
         return $headers;
     }
 
+    private function sendGetRequest($url): ResponseInterface
+    {
+        return $this->client->send(new Request('GET', $url, $this->buildHeaders()), ['verify' => false]);
+    }
+
     /**
      * Get AOD forum member info
      *
@@ -45,7 +50,7 @@ class AODClient
     {
         $url = sprintf('%s/forum_member/%s', $this->baseUrl, $member_id);
 
-        return $this->client->send(new Request('GET', $url, $this->buildHeaders()), ['verify' => false]);
+        return $this->sendGetRequest($url);
     }
 
     /**
@@ -57,6 +62,6 @@ class AODClient
     {
         $url = sprintf('%s/members/%s/update', $this->baseUrl, $discord_member_id);
 
-        return $this->client->send(new Request('GET', $url, $this->buildHeaders()), ['verify' => false]);
+        return $this->sendGetRequest($url);
     }
 }

--- a/app/Services/AODClient.php
+++ b/app/Services/AODClient.php
@@ -36,9 +36,9 @@ class AODClient
         return $headers;
     }
 
-    private function sendGetRequest($url): ResponseInterface
+    private function send($url, $method = 'GET', $body = null): ResponseInterface
     {
-        return $this->client->send(new Request('GET', $url, $this->buildHeaders()), ['verify' => false]);
+        return $this->client->send(new Request($method, $url, $this->buildHeaders(), $body), ['verify' => false]);
     }
 
     /**
@@ -50,7 +50,7 @@ class AODClient
     {
         $url = sprintf('%s/forum_member/%s', $this->baseUrl, $member_id);
 
-        return $this->sendGetRequest($url);
+        return $this->send($url);
     }
 
     /**
@@ -62,6 +62,6 @@ class AODClient
     {
         $url = sprintf('%s/members/%s/update', $this->baseUrl, $discord_member_id);
 
-        return $this->sendGetRequest($url);
+        return $this->send($url);
     }
 }

--- a/app/Services/AODClient.php
+++ b/app/Services/AODClient.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Services;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Psr7\Request;
+use Psr\Http\Message\ResponseInterface;
+
+class AODClient
+{
+    private $baseUrl;
+
+    private $token;
+
+    private $client;
+
+    public function __construct()
+    {
+        $this->baseUrl = config('app.aod.bot_api_base_url');
+        $this->token = config('app.aod.discord_bot_token');
+        $this->client = new Client;
+    }
+
+    private function buildHeaders(): array
+    {
+        $headers = [
+            'Content-Type' => 'application/json',
+            'Authorization' => sprintf('Bearer %s', $this->token),
+        ];
+
+        if (auth()->check()) {
+            array_merge($headers, ['X-Requested-By' => auth()->user()->member->discord_id]);
+        }
+
+        return $headers;
+    }
+
+    /**
+     * Get AOD forum member info
+     *
+     * @throws GuzzleException
+     */
+    public function getForumMember($member_id): ResponseInterface
+    {
+        $url = sprintf('%s/forum_member/%s', $this->baseUrl, $member_id);
+
+        return $this->client->send(new Request('GET', $url, $this->buildHeaders()), ['verify' => false]);
+    }
+
+    /**
+     * Requests an ad-hoc member sync
+     *
+     * @throws GuzzleException
+     */
+    public function updateDiscordMember($discord_member_id): ResponseInterface
+    {
+        $url = sprintf('%s/members/%s/update', $this->baseUrl, $discord_member_id);
+
+        return $this->client->send(new Request('GET', $url, $this->buildHeaders()), ['verify' => false]);
+    }
+}


### PR DESCRIPTION
This PR does two things:

1. Add the AODClient services to communicate with the bot API.
2. Adds the SyncDiscordMember job triggered on a completed recruitment to trigger the Discord bot to sync their profile. 