### PR TITLE
Add leaders data to divisions

### DIFF
--- a/app/Enums/Position.php
+++ b/app/Enums/Position.php
@@ -3,7 +3,6 @@
 namespace App\Enums;
 
 use App\Traits\EnumOptions;
-use Filament\Support\Contracts\HasIcon;
 use Filament\Support\Contracts\HasLabel;
 
 enum Position: int implements HasLabel

--- a/app/Enums/Rank.php
+++ b/app/Enums/Rank.php
@@ -7,7 +7,7 @@ use Filament\Support\Contracts\HasColor;
 use Filament\Support\Contracts\HasLabel;
 use Illuminate\Support\Str;
 
-enum Rank: int implements HasLabel, HasColor
+enum Rank: int implements HasColor, HasLabel
 {
     use EnumOptions;
 

--- a/app/Filament/Resources/DivisionResource.php
+++ b/app/Filament/Resources/DivisionResource.php
@@ -122,7 +122,7 @@ class DivisionResource extends Resource
             ])
             ->filters([
                 Filter::make('is_active')
-                    ->query(fn(Builder $query): Builder => $query->where('active', true))
+                    ->query(fn (Builder $query): Builder => $query->where('active', true))
                     ->label('Hide inactive')
                     ->default(),
             ])

--- a/app/Filament/Resources/LeaveResource.php
+++ b/app/Filament/Resources/LeaveResource.php
@@ -52,11 +52,11 @@ class LeaveResource extends Resource
                         Forms\Components\Textarea::make('body')
                             ->required(),
                         Select::make('type')
-                        ->options([
-                            'misc' => 'Misc',
-                            'negative' => 'Negative',
-                            'positive' => 'Positive',
-                        ])
+                            ->options([
+                                'misc' => 'Misc',
+                                'negative' => 'Negative',
+                                'positive' => 'Positive',
+                            ]),
                     ]),
                 Forms\Components\DateTimePicker::make('end_date')
                     ->required(),

--- a/app/Filament/Resources/MemberResource.php
+++ b/app/Filament/Resources/MemberResource.php
@@ -7,7 +7,6 @@ use App\Enums\Rank;
 use App\Filament\Resources\MemberResource\Pages;
 use App\Models\Member;
 use Filament\Forms;
-use Filament\Forms\Components\BelongsToSelect;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;

--- a/app/Filament/Resources/TransferResource.php
+++ b/app/Filament/Resources/TransferResource.php
@@ -4,7 +4,6 @@ namespace App\Filament\Resources;
 
 use App\Filament\Resources\TransferResource\Pages;
 use App\Models\Transfer;
-use Filament\Forms;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;

--- a/app/Http/Controllers/API/v1/DivisionController.php
+++ b/app/Http/Controllers/API/v1/DivisionController.php
@@ -69,6 +69,7 @@ class DivisionController extends ApiController
                         'members' => $this->memberTransformer->transformCollection(
                             $members->all()
                         ),
+
                     ],
                 ]
             ));
@@ -77,6 +78,9 @@ class DivisionController extends ApiController
         return $this->respond([
             'data' => [
                 'division' => $this->divisionTransformer->transform($division),
+                'leadership' => $this->memberTransformer->transformCollection(
+                    $division->leaders()->get()->all()
+                )
             ],
         ]);
     }

--- a/app/Http/Controllers/API/v1/DivisionController.php
+++ b/app/Http/Controllers/API/v1/DivisionController.php
@@ -11,17 +11,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 class DivisionController extends ApiController
 {
-    private $divisionTransformer;
-
-    private $memberTransformer;
-
     public function __construct(
-        DivisionBasicTransformer $divisionTransformer,
-        MemberBasicTransformer $memberTransformer
-    ) {
-        $this->divisionTransformer = $divisionTransformer;
-        $this->memberTransformer = $memberTransformer;
-    }
+        private readonly DivisionBasicTransformer $divisionTransformer,
+        private readonly MemberBasicTransformer $memberTransformer
+    ) {}
 
     public function update($division, UpdateDivision $request): JsonResponse
     {
@@ -80,7 +73,7 @@ class DivisionController extends ApiController
                 'division' => $this->divisionTransformer->transform($division),
                 'leadership' => $this->memberTransformer->transformCollection(
                     $division->leaders()->get()->all()
-                )
+                ),
             ],
         ]);
     }

--- a/app/Models/Member.php
+++ b/app/Models/Member.php
@@ -269,9 +269,6 @@ class Member extends Model
         return sprintf('https://discordapp.com/users/%d', $this->discord_id);
     }
 
-    /**
-     * @return bool
-     */
     public function isRank(array|Rank $rank): bool
     {
         if (! $this->rank instanceof Rank) {

--- a/app/Presenters/MemberPresenter.php
+++ b/app/Presenters/MemberPresenter.php
@@ -33,7 +33,7 @@ class MemberPresenter extends Presenter
      */
     public function lastActive($activityType, array $skipUnits = [])
     {
-        if (!in_array($activityType, [
+        if (! in_array($activityType, [
             'last_ts_activity',
             'last_voice_activity',
         ])) {
@@ -79,7 +79,7 @@ class MemberPresenter extends Presenter
                         ? "<strong>{$prefix}</strong>"
                         : null,
                     '{title}' => $title,
-                    '{name}' => $name
+                    '{name}' => $name,
                 ]
             );
         }
@@ -98,6 +98,6 @@ class MemberPresenter extends Presenter
             return $this->member->name;
         }
 
-        return $this->member->rank->getAbbreviation().' '.$this->member->name;
+        return $this->member->rank->getAbbreviation() . ' ' . $this->member->name;
     }
 }

--- a/app/Transformers/DivisionBasicTransformer.php
+++ b/app/Transformers/DivisionBasicTransformer.php
@@ -4,6 +4,8 @@ namespace App\Transformers;
 
 class DivisionBasicTransformer extends Transformer
 {
+    public function __construct(private readonly MemberBasicTransformer $memberTransformer){}
+
     public function transform($item): array
     {
         return [
@@ -15,6 +17,9 @@ class DivisionBasicTransformer extends Transformer
             'members_count' => $item->members_count,
             'officer_channel' => $item->settings()->get('officer_channel'),
             'icon' => $item->getLogoPath(),
+            'leadership' => $this->memberTransformer->transformCollection(
+                $item->leaders()->get()->all()
+            )
         ];
     }
 }

--- a/app/Transformers/DivisionBasicTransformer.php
+++ b/app/Transformers/DivisionBasicTransformer.php
@@ -4,7 +4,7 @@ namespace App\Transformers;
 
 class DivisionBasicTransformer extends Transformer
 {
-    public function __construct(private readonly MemberBasicTransformer $memberTransformer){}
+    public function __construct(private readonly MemberBasicTransformer $memberTransformer) {}
 
     public function transform($item): array
     {
@@ -19,7 +19,7 @@ class DivisionBasicTransformer extends Transformer
             'icon' => $item->getLogoPath(),
             'leadership' => $this->memberTransformer->transformCollection(
                 $item->leaders()->get()->all()
-            )
+            ),
         ];
     }
 }

--- a/app/Transformers/MemberBasicTransformer.php
+++ b/app/Transformers/MemberBasicTransformer.php
@@ -12,11 +12,9 @@ class MemberBasicTransformer extends Transformer
     {
         return [
             'name' => $item->name,
-            'join_date' => $item->join_date,
-            'last_activity' => $item->last_activity,
-            'last_ts_activity' => $item->last_ts_activity,
-            'rank_id' => $item->rank_id,
-            'division_id' => $item->division_id,
+            'position' => $item->position->getLabel(),
+            'rank' => $item->rank->getAbbreviation(),
+            'discord_id' => $item->discord_id,
         ];
     }
 }

--- a/app/Transformers/MemberFullTransformer.php
+++ b/app/Transformers/MemberFullTransformer.php
@@ -15,7 +15,7 @@ class MemberFullTransformer extends Transformer
             'join_date' => $item->join_date,
             'last_activity' => $item->last_activity,
             'last_ts_activity' => $item->last_ts_activity,
-            'rank_id' => $item->rank_id,
+            'rank' => $item->rank->getAbbreviation(),
             'division_id' => $item->division_id,
             'position' => $item->position->getLabel(),
             'discord_id' => $item->discord_id,

--- a/app/Transformers/MemberFullTransformer.php
+++ b/app/Transformers/MemberFullTransformer.php
@@ -17,6 +17,8 @@ class MemberFullTransformer extends Transformer
             'last_ts_activity' => $item->last_ts_activity,
             'rank_id' => $item->rank_id,
             'division_id' => $item->division_id,
+            'position' => $item->position->getLabel(),
+            'discord_id' => $item->discord_id,
         ], \count($item->handles) ? [
             'handles' => $item->handles,
         ] : []);


### PR DESCRIPTION
Also removes some data from the basic member transform, and expands some values (rank, position) now that they are enums and won't result in nested queries