### PR TITLE
Add additional info to recruitment and removal messages

### DIFF
--- a/app/Filament/Resources/HandleResource.php
+++ b/app/Filament/Resources/HandleResource.php
@@ -40,7 +40,7 @@ class HandleResource extends Resource
     {
         return $table
             ->columns([
-                Tables\Columns\TextColumn::make('type')
+                Tables\Columns\TextColumn::make('label')
                     ->searchable(),
                 Tables\Columns\TextColumn::make('comments')
                     ->searchable(),

--- a/app/Http/Controllers/RecruitingController.php
+++ b/app/Http/Controllers/RecruitingController.php
@@ -146,11 +146,7 @@ class RecruitingController extends Controller
     public function validateMemberId($member_id)
     {
         if (app()->environment() === 'local') {
-            if ($member_id === 31832) {
-                return ['is_member' => true, 'verified_email' => true];
-            }
-
-            return ['is_member' => false, 'verified_email' => false];
+            return ['is_member' => true, 'verified_email' => true];
         }
 
         $result = $this->callProcedure('get_user', $member_id);

--- a/app/Http/Requests/DeleteMember.php
+++ b/app/Http/Requests/DeleteMember.php
@@ -41,7 +41,7 @@ class DeleteMember extends FormRequest
 
         if ($member->division()->exists()) {
             if ($member->division->settings()->get('slack_alert_removed_member')) {
-                $member->division->notify(new MemberRemoved($member, auth()->user(), $this->removal_reason));
+                $member->division->notify(new MemberRemoved($member, auth()->user(), $this->removal_reason, $member->squad));
             }
         }
 

--- a/app/Notifications/NewExternalRecruit.php
+++ b/app/Notifications/NewExternalRecruit.php
@@ -47,6 +47,7 @@ class NewExternalRecruit extends Notification implements ShouldQueue
     public function toBot($notifiable)
     {
         $recruiter = $this->recruiter;
+        $handle = $this->member->handles->filter(fn ($handle) => $handle->id === $this->member->division->handle_id)->first();
 
         return (new BotChannelMessage($notifiable))
             ->title($notifiable->name . ' Division')
@@ -62,6 +63,22 @@ class NewExternalRecruit extends Notification implements ShouldQueue
                         route('member', $this->member->getUrlParams()),
                         $notifiable->name
                     ),
+                ],
+                [
+                    'name' => sprintf(
+                        '%s / %s',
+                        $this->member->division->locality('platoon'),
+                        $this->member->division->locality('squad')
+                    ),
+                    'value' => $this->member->squad ? sprintf(
+                        '%s / %s',
+                        $this->member->platoon->name,
+                        $this->member->squad->name
+                    ) : 'Unassigned',
+                ],
+                [
+                    'name' => $handle->label ?? 'In-Game Handle',
+                    'value' => $handle->pivot->value ?? 'N/A',
                 ],
             ])
             ->info()

--- a/app/Notifications/NewMemberRecruited.php
+++ b/app/Notifications/NewMemberRecruited.php
@@ -49,6 +49,7 @@ class NewMemberRecruited extends Notification implements ShouldQueue
     public function toBot($notifiable)
     {
         $recruiter = $this->recruiter;
+        $handle = $this->member->handles->filter(fn ($handle) => $handle->id === $this->member->division->handle_id)->first();
 
         return (new BotChannelMessage($notifiable))
             ->title($notifiable->name . ' Division')
@@ -61,6 +62,22 @@ class NewMemberRecruited extends Notification implements ShouldQueue
                         $recruiter->name,
                         route('member', $this->member->getUrlParams())
                     ),
+                ],
+                [
+                    'name' => sprintf(
+                        '%s / %s',
+                        $this->member->division->locality('platoon'),
+                        $this->member->division->locality('squad')
+                    ),
+                    'value' => $this->member->squad ? sprintf(
+                        '%s / %s',
+                        $this->member->platoon->name,
+                        $this->member->squad->name
+                    ) : 'Unassigned',
+                ],
+                [
+                    'name' => $handle->label ?? 'In-Game Handle',
+                    'value' => $handle->pivot->value ?? 'N/A',
                 ],
             ])
             ->success()

--- a/app/Notifications/PartTimeMemberRemoved.php
+++ b/app/Notifications/PartTimeMemberRemoved.php
@@ -50,21 +50,29 @@ class PartTimeMemberRemoved extends Notification implements ShouldQueue
      */
     public function toBot($notifiable)
     {
+        $handle = $this->member->handles->filter(fn ($handle) => $handle->id === $notifiable->handle_id)->first();
+
         return (new BotChannelMessage($notifiable))
             ->title($this->primaryDivision->name . ' Division')
             ->thumbnail($this->primaryDivision->getLogoPath())
             ->fields([
                 [
-                    'name' => '**PART TIME MEMBER REMOVED**',
-                    'value' => addslashes(":door: {$this->member->name} [{$this->member->clan_id}] was removed from {$this->primaryDivision->name}, and they were a part-time member in your division"),
+                    'name' => 'Part Time Member Removed',
+                    'value' => sprintf(
+                        ':door: [%s](%s) [%d] was removed from %s and they were a part-time member in your division',
+                        $this->member->name,
+                        route('member', $this->member->getUrlParams()),
+                        $this->member->clan_id,
+                        $this->primaryDivision->name,
+                    ),
                 ],
                 [
                     'name' => 'Reason',
                     'value' => addslashes($this->removalReason),
                 ],
                 [
-                    'name' => 'View Member Profile',
-                    'value' => route('member', $this->member->getUrlParams()),
+                    'name' => $handle->label ?? 'In-Game Handle',
+                    'value' => $handle->pivot->value ?? 'N/A',
                 ],
             ])->error()
             ->send();

--- a/database/factories/HandleFactory.php
+++ b/database/factories/HandleFactory.php
@@ -21,7 +21,7 @@ class HandleFactory extends Factory
     public function definition(): array
     {
         $handles = [
-            'origin', 'ea', 'blizzard', 'steam', 'activision', 'riot', 'battle tag', 'wows', 'xbox-live',
+            'origin', 'ea', 'blizzard', 'steam', 'activision', 'riot', 'battle tag', 'wows', 'xbox live',
         ];
 
         $label = $handles[array_rand($handles)];

--- a/resources/views/member/forms/remove-member-form.blade.php
+++ b/resources/views/member/forms/remove-member-form.blade.php
@@ -21,7 +21,7 @@
 
         <div class="form-group">
             <label for="removal_reason">Reason</label>
-            <textarea name="removal_reason" id="removal_reason" rows="3" class="form-control" required="required">Member removed. Reason: </textarea>
+            <textarea name="removal_reason" id="removal_reason" rows="3" class="form-control" required="required"></textarea>
         </div>
     </div>
     <div class="panel-footer">


### PR DESCRIPTION
This PR adds the member's in-game handle and platoon/squad to Discord recruitment and removal notifications. The additional information will help some divisions that may need further action after recruitment or removal, such as in-game clan/outfit management activities.

Recruitment Notification
![image](https://github.com/user-attachments/assets/2b46d8b3-eb23-4401-8c24-569dcfca6389)

Main Division Removal Notification
![image](https://github.com/user-attachments/assets/85278a5d-f4af-4c94-b42a-9efd6467e51e)

Part Time Divsion Removal Notification
![image](https://github.com/user-attachments/assets/e53ba346-a398-46c6-84fa-6013962bfdb3)
