### PR TITLE
Query in-game handles in addition to member name when searching

### DIFF
--- a/app/Http/Controllers/MemberController.php
+++ b/app/Http/Controllers/MemberController.php
@@ -52,8 +52,16 @@ class MemberController extends Controller
         }
 
         if ($name) {
-            $members = Member::where('name', 'LIKE', "%{$name}%")
-                ->with('division')->get();
+            $member_name = Member::where('name', 'LIKE', "%{$name}%")
+                ->with('division');
+
+            $members = Member::withWhereHas('handles', function ($query) use ($name) {
+                $query->where('value', 'LIKE', "%{$name}%");
+            })
+                ->with('division')
+                ->union($member_name)
+                ->orderBy('name')
+                ->get();
         } else {
             $members = [];
         }

--- a/resources/views/member/search-ajax.blade.php
+++ b/resources/views/member/search-ajax.blade.php
@@ -5,7 +5,11 @@
             <h5 class="m-b-none">
                 {!! $member->present()->rankName !!}
             </h5>
-            <small class="slight">{{ $member->division->name ?? "Ex-AOD" }} [{{ $member->clan_id }}]</small>
+            <div><small class="slight">{{ $member->division->name ?? "Ex-AOD" }} [{{ $member->clan_id }}]</small></div>
+            @if (count($member->handles) > 0)
+                <div><small class="slight">{{ $member->handles->first()->pivot->value }}
+                        [{{ $member->handles->first()->label }}]</small></div>
+            @endif
         </div>
     </a>
 @empty

--- a/resources/views/member/search.blade.php
+++ b/resources/views/member/search.blade.php
@@ -6,7 +6,7 @@
             v3
         @endslot
         @slot ('icon')
-            <img src="{{ asset(config('app.logo')) }}" width="50px" />
+            <img src="{{ asset(config('app.logo')) }}" width="50px"/>
         @endslot
         @slot ('heading')
             AOD Tracker
@@ -21,22 +21,26 @@
         <h4>Search Members</h4>
         <form action="{{ route('memberSearch') }}">
             <div class="form-group" style="position: relative">
-                <input type="text" class="form-control" name="name" value="{{ request()->name }}" />
+                <input type="text" class="form-control" name="name" value="{{ request()->name }}"/>
                 <i class="fa fa-search pull-right" style="position: absolute; right: 10px; top: 10px;"></i>
             </div>
         </form>
 
         @if (request()->name)
-            <hr />
+            <hr/>
             @forelse($members as $member)
                 <a class="panel" href="{{ route('member', $member->getUrlParams()) }}"
                    style="padding-left: 30px; margin-bottom: 0;">
                     <div class="panel-body">
                         <h4 class="m-b-none">
                             <span class="slight">{{ $loop->iteration }}. </span>
-                            {!! Str::limit($member->present()->rankName, 15) !!}
+                            {{ $member->present()->rankName }}
                             <small class="slight text-muted">[{{ $member->clan_id }}]</small>
                             <small class="pull-right">{{ $member->division->name ?? "Ex-AOD" }}</small>
+                            @if (count($member->handles) > 0)
+                                <div><small class="slight">{{ $member->handles->first()->pivot->value }}
+                                        [{{ $member->handles->first()->label }}]</small></div>
+                            @endif
                         </h4>
                     </div>
                 </a>


### PR DESCRIPTION
Add in-game handle as another criterion to match when searching via the search bar or search page. Matches based on in-game handle will display the matched handle as part of the search results. If multiple handles match for a single member, only the first match is displayed. 

![image](https://github.com/user-attachments/assets/df1ab379-c49c-4f53-a074-d225c648b7a8)

Closes #193 
