### PR TITLE
Hotfix member search

### DIFF
--- a/app/Filament/Mod/Resources/DivisionResource.php
+++ b/app/Filament/Mod/Resources/DivisionResource.php
@@ -47,7 +47,9 @@ class DivisionResource extends Resource
                         Forms\Components\Repeater::make('locality')->schema([
                             Forms\Components\TextInput::make('old-string')->readOnly(),
                             Forms\Components\TextInput::make('new-string'),
-                        ])->reorderable(false)->columns()->addable(false),
+                        ])->reorderable(false)->columns()
+                            ->addable(false)
+                            ->deletable(false),
                     ]),
 
                 Forms\Components\Section::make('Recruiting')->collapsible()->collapsed()

--- a/app/Filament/Mod/Resources/MemberAwardResource.php
+++ b/app/Filament/Mod/Resources/MemberAwardResource.php
@@ -30,8 +30,13 @@ class MemberAwardResource extends Resource
                     ->relationship('award', 'name'),
 
                 Forms\Components\Select::make('member_id')
+                    ->relationship('member', 'name', function (Builder $query) {
+                        $query->whereHas('division', function (Builder $subQuery) {
+                            $subQuery->where('active', true);
+                        });
+                    })
                     ->searchable()
-                    ->relationship('member', 'name'),
+                    ->required(),
 
                 Forms\Components\Textarea::make('reason')
                     ->columnSpanFull()
@@ -56,7 +61,8 @@ class MemberAwardResource extends Resource
                     ->numeric()
                     ->searchable()
                     ->sortable(),
-                Tables\Columns\TextColumn::make('member.name')->searchable(),
+                Tables\Columns\TextColumn::make('member.name')
+                    ->searchable(),
                 Tables\Columns\TextColumn::make('reason')
                     ->toggleable(),
 

--- a/app/Filament/Mod/Resources/RankActionResource.php
+++ b/app/Filament/Mod/Resources/RankActionResource.php
@@ -10,6 +10,7 @@ use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 
 class RankActionResource extends Resource
 {
@@ -24,7 +25,11 @@ class RankActionResource extends Resource
         return $form
             ->schema([
                 Forms\Components\Select::make('member_id')
-                    ->relationship(name: 'member', titleAttribute: 'name')
+                    ->relationship('member', 'name', function (Builder $query) {
+                        $query->whereHas('division', function (Builder $subQuery) {
+                            $subQuery->where('active', true);
+                        });
+                    })
                     ->searchable()
                     ->required(),
                 Forms\Components\Select::make('rank')


### PR DESCRIPTION
- Filter member searches for awards and ranks to only those in an active division
- Prevent deletion of locality repeater fields