### PR TITLE
Add settable trait, clean up logic

### DIFF
--- a/app/Filament/Mod/Resources/DivisionResource.php
+++ b/app/Filament/Mod/Resources/DivisionResource.php
@@ -116,11 +116,11 @@ class DivisionResource extends Resource
                                 Forms\Components\Select::make('member_approved')
                                     ->options($channelOptions)
                                     ->label('New Recruit Approval'),
-                                Forms\Components\Select::make('member_denied')
-                                    ->options($channelOptions)
-                                    ->label('New Recruit Denial'),
+//                                Forms\Components\Select::make('member_denied')
+//                                    ->options($channelOptions)
+//                                    ->label('New Recruit Denial'),
                             ])
-                            ->columns(3),
+                            ->columns(2),
 
                         Fieldset::make('Membership Changes')
                             ->schema([

--- a/app/Filament/Mod/Resources/DivisionResource/Pages/EditDivision.php
+++ b/app/Filament/Mod/Resources/DivisionResource/Pages/EditDivision.php
@@ -24,10 +24,7 @@ class EditDivision extends EditRecord
     protected function handleRecordUpdate(Model $record, array $data): Model
     {
         $record->update($data);
-
-        if ($record->settings()->get('chat_alerts.division_edited')) {
-            $record->notify(new DivisionEdited(auth()->user()->name));
-        }
+        $record->notify(new DivisionEdited(auth()->user()->name));
 
         return $record;
     }

--- a/app/Http/Controllers/Admin/MemberRequestController.php
+++ b/app/Http/Controllers/Admin/MemberRequestController.php
@@ -116,13 +116,10 @@ class MemberRequestController extends Controller
 
         $memberRequest = MemberRequest::find($requestId);
 
-        if ($memberRequest->division->settings()->get('chat_alerts.member_approved')) {
-            $memberRequest->division->notify(new MemberRequestApproved(
-                $memberRequest,
-                auth()->user(),
-                $memberRequest->member
-            ));
-        }
+        $memberRequest->division->notify(new MemberRequestApproved(
+            auth()->user(),
+            $memberRequest->member
+        ));
 
         $memberRequest->approve();
 

--- a/app/Http/Controllers/RecruitingController.php
+++ b/app/Http/Controllers/RecruitingController.php
@@ -50,18 +50,12 @@ class RecruitingController extends Controller
 
         $division = Division::whereSlug($request->division)->first();
 
-        // create or update member record
         $member = $this->createMember($request);
 
-        // request member status
         $this->createRequest($member, $division);
 
-        // notify slack of recruitment
-        if ($division->settings()->get('chat_alerts.member_created')) {
-            $this->handleNotification($request, $member, $division);
-        }
+        $this->handleNotification($request, $member, $division);
 
-        // create job to sync discord member
         SyncDiscordMember::dispatch($member);
 
         $this->showSuccessToast('Your recruitment has successfully been completed!');

--- a/app/Http/Requests/DeleteMember.php
+++ b/app/Http/Requests/DeleteMember.php
@@ -5,6 +5,7 @@ namespace App\Http\Requests;
 use App\Models\Member;
 use App\Models\Note;
 use App\Notifications\MemberRemoved;
+use App\Notifications\PartTimeMemberRemoved;
 use Illuminate\Foundation\Http\FormRequest;
 
 class DeleteMember extends FormRequest
@@ -40,9 +41,9 @@ class DeleteMember extends FormRequest
         $member = $this->route('member');
 
         if ($member->division()->exists()) {
-            if ($member->division->settings()->get('chat_alerts.member_removed')) {
-                $member->division->notify(new MemberRemoved($member, auth()->user(), $this->removal_reason, $member->squad));
-            }
+            $member->division->notify(
+                new MemberRemoved($member, auth()->user(), $this->removal_reason, $member->squad)
+            );
         }
 
         $this->notifyPartTimeDivisions($member);
@@ -65,9 +66,7 @@ class DeleteMember extends FormRequest
         $divisions = $member->partTimeDivisions()->active()->get();
 
         foreach ($divisions as $division) {
-            if ($division->settings()->get('chat_alerts.pt_member_removed')) {
-                $division->notify(new \App\Notifications\PartTimeMemberRemoved($member, $this->removal_reason));
-            }
+            $division->notify(new PartTimeMemberRemoved($member, $this->removal_reason));
         }
     }
 }

--- a/app/Notifications/DivisionEdited.php
+++ b/app/Notifications/DivisionEdited.php
@@ -4,6 +4,7 @@ namespace App\Notifications;
 
 use App\Channels\BotChannel;
 use App\Channels\Messages\BotChannelMessage;
+use App\Traits\DivisionSettableNotification;
 use App\Traits\RetryableNotification;
 use Exception;
 use Illuminate\Bus\Queueable;
@@ -12,7 +13,9 @@ use Illuminate\Notifications\Notification;
 
 class DivisionEdited extends Notification implements ShouldQueue
 {
-    use Queueable, RetryableNotification;
+    use DivisionSettableNotification, Queueable, RetryableNotification;
+
+    private string $alertSetting = 'chat_alerts.division_edited';
 
     public function __construct(private $user) {}
 
@@ -36,7 +39,7 @@ class DivisionEdited extends Notification implements ShouldQueue
     {
         return (new BotChannelMessage($notifiable))
             ->title($notifiable->name . ' Division')
-            ->target($notifiable->settings()->get('chat_alerts.division_edited'))
+            ->target($notifiable->settings()->get($this->alertSetting))
             ->thumbnail($notifiable->getLogoPath())
             ->message(sprintf('%s updated the division settings', $this->user))
             ->info()

--- a/app/Notifications/MemberNameChanged.php
+++ b/app/Notifications/MemberNameChanged.php
@@ -14,12 +14,7 @@ class MemberNameChanged extends Notification implements ShouldQueue
 {
     use Queueable, RetryableNotification;
 
-    private $names;
-
-    public function __construct($names)
-    {
-        $this->names = $names;
-    }
+    public function __construct(private readonly array $names) {}
 
     public function via($notifiable)
     {
@@ -37,7 +32,11 @@ class MemberNameChanged extends Notification implements ShouldQueue
         return (new BotChannelMessage($notifiable))
             ->title($notifiable->name . ' Division')
             ->thumbnail($notifiable->getLogoPath())
-            ->message(addslashes(":tools: **MEMBER STATUS - NAME CHANGE**\n`{$this->names['oldName']}` is now known as `{$this->names['newName']}`. Please inform the member of this change."))
+            ->message(addslashes(sprintf(
+                ":tools: **MEMBER STATUS - NAME CHANGE**\n`%s` is now known as `%s`. Please inform the member of this change.",
+                $this->names['oldName'],
+                $this->names['newName']
+            )))
             ->success()
             ->send();
     }

--- a/app/Notifications/MemberRequestApproved.php
+++ b/app/Notifications/MemberRequestApproved.php
@@ -5,8 +5,8 @@ namespace App\Notifications;
 use App\Channels\BotChannel;
 use App\Channels\Messages\BotChannelMessage;
 use App\Models\Member;
-use App\Models\MemberRequest;
 use App\Models\User;
+use App\Traits\DivisionSettableNotification;
 use App\Traits\RetryableNotification;
 use Exception;
 use Illuminate\Bus\Queueable;
@@ -15,20 +15,19 @@ use Illuminate\Notifications\Notification;
 
 class MemberRequestApproved extends Notification implements ShouldQueue
 {
-    use Queueable, RetryableNotification;
-
-    private $request;
+    use DivisionSettableNotification, Queueable, RetryableNotification;
 
     private User $approver;
 
     private Member $member;
 
+    private string $alertSetting = 'chat_alerts.member_approved';
+
     /**
      * Create a new notification instance.
      */
-    public function __construct(MemberRequest $memberRequest, User $approver, Member $member)
+    public function __construct(User $approver, Member $member)
     {
-        $this->request = $memberRequest;
         $this->member = $member;
         $this->approver = $approver;
     }
@@ -54,7 +53,7 @@ class MemberRequestApproved extends Notification implements ShouldQueue
     {
         return (new BotChannelMessage($notifiable))
             ->title($notifiable->name . ' Division')
-            ->target($notifiable->settings()->get('chat_alerts.member_approved'))
+            ->target($notifiable->settings()->get($this->alertSetting))
             ->thumbnail($notifiable->getLogoPath())
             ->message(addslashes("**MEMBER STATUS REQUEST** - :thumbsup: A member status request for `{$this->member->name}` was approved by {$this->approver->name}!"))
             ->success()

--- a/app/Notifications/MemberTransferred.php
+++ b/app/Notifications/MemberTransferred.php
@@ -4,8 +4,8 @@ namespace App\Notifications;
 
 use App\Channels\BotChannel;
 use App\Channels\Messages\BotChannelMessage;
-use App\Models\Division;
 use App\Models\Member;
+use App\Traits\DivisionSettableNotification;
 use App\Traits\RetryableNotification;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -13,20 +13,17 @@ use Illuminate\Notifications\Notification;
 
 class MemberTransferred extends Notification implements ShouldQueue
 {
-    use Queueable, RetryableNotification;
+    use DivisionSettableNotification, Queueable, RetryableNotification;
 
-    private Member $member;
-
-    private Division $destinationDivision;
+    private string $alertSetting = 'chat_alerts.member_transferred';
 
     /**
      * Create a new notification instance.
      */
-    public function __construct(Member $member, Division $destinationDivision)
-    {
-        $this->member = $member;
-        $this->destinationDivision = $destinationDivision;
-    }
+    public function __construct(
+        private readonly Member $member,
+        private readonly string $destinationDivision
+    ) {}
 
     /**
      * Get the notification's delivery channels.
@@ -47,13 +44,18 @@ class MemberTransferred extends Notification implements ShouldQueue
     public function toBot($notifiable)
     {
         return (new BotChannelMessage($notifiable))
-            ->title($this->destinationDivision->name . ' Division')
-            ->target($notifiable->settings()->get('chat_alerts.member_transferred'))
-            ->thumbnail($this->destinationDivision->getLogoPath())
+            ->title($notifiable->name . ' Division')
+            ->target($notifiable->settings()->get($this->alertSetting))
+            ->thumbnail($notifiable->getLogoPath())
             ->fields([
                 [
                     'name' => '**MEMBER TRANSFER**',
-                    'value' => addslashes(":recycle: {$this->member->name} [{$this->member->clan_id}] transferred to {$this->destinationDivision->name}"),
+                    'value' => addslashes(sprintf(
+                        ':recycle: %s [%s] transferred to %s',
+                        $this->member->name,
+                        $this->member->clan_id,
+                        $this->destinationDivision
+                    )),
                 ],
             ])->info()
             ->send();

--- a/app/Notifications/NewExternalRecruit.php
+++ b/app/Notifications/NewExternalRecruit.php
@@ -4,7 +4,9 @@ namespace App\Notifications;
 
 use App\Channels\BotChannel;
 use App\Channels\Messages\BotChannelMessage;
+use App\Models\Member;
 use App\Models\User;
+use App\Traits\DivisionSettableNotification;
 use App\Traits\RetryableNotification;
 use Exception;
 use Illuminate\Bus\Queueable;
@@ -13,20 +15,14 @@ use Illuminate\Notifications\Notification;
 
 class NewExternalRecruit extends Notification implements ShouldQueue
 {
-    use Queueable, RetryableNotification;
+    use DivisionSettableNotification, Queueable, RetryableNotification;
 
-    private $member;
-
-    private User $recruiter;
+    private string $alertSetting = 'chat_alerts.member_created';
 
     /**
      * Create a new notification instance.
      */
-    public function __construct($member, User $recruiter)
-    {
-        $this->member = $member;
-        $this->recruiter = $recruiter;
-    }
+    public function __construct(private readonly Member $member, private readonly User $recruiter) {}
 
     /**
      * Get the notification's delivery channels.
@@ -52,7 +48,7 @@ class NewExternalRecruit extends Notification implements ShouldQueue
 
         return (new BotChannelMessage($notifiable))
             ->title($notifiable->name . ' Division')
-            ->target($notifiable->settings()->get('chat_alerts.member_created'))
+            ->target($notifiable->settings()->get($this->alertSetting))
             ->thumbnail($notifiable->getLogoPath())
             ->fields([
                 [

--- a/app/Traits/DivisionSettableNotification.php
+++ b/app/Traits/DivisionSettableNotification.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Traits;
+
+use App\Models\Division;
+
+trait DivisionSettableNotification
+{
+    public function shouldSend(Division $notifiable): bool
+    {
+        if (! property_exists($this, 'alertSetting')) {
+            throw new \Exception('The $alertSetting property must be defined in ' . static::class);
+        }
+
+        return $notifiable->settings()->get($this->alertSetting);
+    }
+}


### PR DESCRIPTION
So we can remove the conditional logic and centralize alert setting references inside the relevant notifications

Also cleans up unused arguments, replaces some passed instances for strings, and finally replaces older property declarations in favor of constructor arguments

Refactors member sync division transfer lookups to be a single query

Hides "member request denied" setting since... that's currently not a thing