### PR TITLE
Notify only on promotions

### DIFF
--- a/app/Enums/Rank.php
+++ b/app/Enums/Rank.php
@@ -109,4 +109,9 @@ enum Rank: int implements HasColor, HasLabel
 
         return $ranks;
     }
+
+    public function isPromotion(Rank $previousRank): bool
+    {
+        return $this->value > $previousRank->value;
+    }
 }

--- a/app/Filament/Mod/Resources/DivisionResource.php
+++ b/app/Filament/Mod/Resources/DivisionResource.php
@@ -26,8 +26,8 @@ class DivisionResource extends Resource
     public static function form(Form $form): Form
     {
         $channelOptions = [
-            'officers' => 'Officer Channel',
-            'members' => 'Members Channel',
+            'officers' => 'Officers',
+            'members' => 'Members',
             false => 'Disabled',
         ];
 
@@ -142,9 +142,9 @@ class DivisionResource extends Resource
                                 Forms\Components\Select::make('division_edited')
                                     ->options($channelOptions)
                                     ->label('Division Settings Changes'),
-                                Forms\Components\Select::make('rank_changed')
+                                Forms\Components\Select::make('member_promoted')
                                     ->options($channelOptions)
-                                    ->label('Member Rank Changes'),
+                                    ->label('Member Promoted'),
                                 Forms\Components\Select::make('member_awarded')
                                     ->options($channelOptions)
                                     ->label('Member Awarded'),

--- a/app/Notifications/Promotion.php
+++ b/app/Notifications/Promotion.php
@@ -10,7 +10,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Notification;
 
-class MemberRankChanged extends Notification implements ShouldQueue
+class Promotion extends Notification implements ShouldQueue
 {
     use Queueable, RetryableNotification;
 
@@ -31,9 +31,9 @@ class MemberRankChanged extends Notification implements ShouldQueue
     {
         return (new BotChannelMessage($notifiable))
             ->title($notifiable->name . ' Division')
-            ->target($notifiable->settings()->get('chat_alerts.rank_changed'))
+            ->target($notifiable->settings()->get('chat_alerts.promotion'))
             ->thumbnail($notifiable->getLogoPath())
-            ->message(addslashes(":tools: **MEMBER STATUS - RANK CHANGE**\n{$this->member} is now  `{$this->rank}`"))
+            ->message(addslashes(":tools: **PROMOTION**\n{$this->member} is promoted to  `{$this->rank}`"))
             ->success()
             ->send();
     }

--- a/database/migrations/2025_01_30_104749_rename_rank_changed_setting_to_member_promoted.php
+++ b/database/migrations/2025_01_30_104749_rename_rank_changed_setting_to_member_promoted.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        DB::table('divisions')->get()->each(function ($row) {
+            $settings = json_decode($row->settings, true);
+
+            if (isset($settings['chat_alerts']['rank_changed'])) {
+                $settings['chat_alerts']['member_promoted'] = $settings['chat_alerts']['rank_changed'];
+                unset($settings['chat_alerts']['rank_changed']);
+
+                DB::table('divisions')
+                    ->where('id', $row->id)
+                    ->update(['settings' => json_encode($settings)]);
+            }
+        });
+    }
+
+    public function down()
+    {
+        DB::table('divisions')->get()->each(function ($row) {
+            $settings = json_decode($row->settings, true);
+
+            if (isset($settings['chat_alerts']['member_promoted'])) {
+                $settings['chat_alerts']['rank_changed'] = $settings['chat_alerts']['member_promoted'];
+                unset($settings['chat_alerts']['member_promoted']);
+
+                DB::table('divisions')
+                    ->where('id', $row->id)
+                    ->update(['settings' => json_encode($settings)]);
+            }
+        });
+    }
+};


### PR DESCRIPTION
- Rename `rank_changed` to `member_promoted` to explicitly define the action, notification
- Add a `isPromotion` helper to rank enum
- Refactor sync to report promotions
- Shorten dropdown label for channel options