### PR TITLE
Release filter

### DIFF
--- a/app/Filament/Mod/Resources/RankActionResource.php
+++ b/app/Filament/Mod/Resources/RankActionResource.php
@@ -53,6 +53,14 @@ class RankActionResource extends Resource
                     Forms\Components\Section::make('Rank Action Details')
                         ->hiddenOn('create')
                         ->schema([
+                            Forms\Components\Fieldset::make('Dates')->schema([
+                                Forms\Components\DateTimePicker::make('approved_at')
+                                    ->visible(fn($record) => $record->approved_at)
+                                    ->readOnly(),
+                                Forms\Components\DateTimePicker::make('created_at')
+                                    ->label('Requested At')
+                                    ->readOnly()
+                            ]),
                             Select::make('rank')
                                 ->options(Rank::class)
                                 ->disabledOn('edit'),
@@ -73,12 +81,6 @@ class RankActionResource extends Resource
                             ViewField::make('type')
                                 ->view('filament.forms.components.type-badge')
                                 ->viewData(['record']),
-                            Forms\Components\DateTimePicker::make('approved_at')
-                                ->visible(fn ($record) => $record->approved_at)
-                                ->readOnly(),
-                            Forms\Components\DateTimePicker::make('requested_at')
-                                ->visible(fn ($record) => $record->requested_at)
-                                ->readOnly(),
                         ])
                         ->grow(false),
 

--- a/app/Filament/Mod/Resources/RankActionResource.php
+++ b/app/Filament/Mod/Resources/RankActionResource.php
@@ -384,7 +384,9 @@ class RankActionResource extends Resource
     {
         return Forms\Components\RichEditor::make('justification')
             ->required()
-            ->hidden(fn ($record) => $record?->requester_id && $record->requester_id !== auth()->user()->member_id)
+            ->hidden(fn ($record) => ($record?->requester_id && $record->requester_id !== auth()->user()->member_id)
+                || $record->accepted_at
+            )
             ->columnSpanFull();
     }
 }

--- a/app/Filament/Mod/Resources/RankActionResource.php
+++ b/app/Filament/Mod/Resources/RankActionResource.php
@@ -55,11 +55,11 @@ class RankActionResource extends Resource
                         ->schema([
                             Forms\Components\Fieldset::make('Dates')->schema([
                                 Forms\Components\DateTimePicker::make('approved_at')
-                                    ->visible(fn($record) => $record->approved_at)
+                                    ->visible(fn ($record) => $record->approved_at)
                                     ->readOnly(),
                                 Forms\Components\DateTimePicker::make('created_at')
                                     ->label('Requested At')
-                                    ->readOnly()
+                                    ->readOnly(),
                             ]),
                             Select::make('rank')
                                 ->options(Rank::class)


### PR DESCRIPTION
- Allows visibility of past rank actions via filter
- Hides the justification edit field after a promotion is accepted
- Improves how dates (requested at, approved at) are displayed