### PR TITLE
Fix division leader perms, remove deleteAny

### DIFF
--- a/app/Filament/Mod/Resources/PlatoonResource.php
+++ b/app/Filament/Mod/Resources/PlatoonResource.php
@@ -26,9 +26,15 @@ class PlatoonResource extends Resource
 
     protected static ?string $navigationGroup = 'Division';
 
-    public static function canDeleteAny(): bool
+    public static function canDelete($record): bool
     {
-        return auth()->user()->isRole(['admin', 'sr_ldr']) || auth()->user()->isDivisionLeader();
+        if (auth()->user()->isRole(['admin'])) {
+            return true;
+        }
+
+        if (auth()->user()->isRole(['sr_ldr']) || auth()->user()->isDivisionLeader()) {
+            return $record->division_id === auth()->user()->member->division_id;
+        }
     }
 
     public static function canEdit(Model $record): bool
@@ -68,7 +74,7 @@ class PlatoonResource extends Resource
                         ->placeholder('https://')
                         ->maxLength(255)
                         ->default(null),
-                ]),
+                ])->columns(),
 
                 Forms\Components\Section::make('Leadership')
                     ->hiddenOn('create')

--- a/app/Filament/Mod/Resources/PlatoonResource/Pages/EditPlatoon.php
+++ b/app/Filament/Mod/Resources/PlatoonResource/Pages/EditPlatoon.php
@@ -76,7 +76,9 @@ class EditPlatoon extends EditRecord
     {
         return [
 
-            Actions\DeleteAction::make()->action(function ($record) {
+            Actions\DeleteAction::make()
+                ->modalDescription('Assigned members will be removed from this platoon and any squads within. Are you sure?')
+                ->action(function ($record) {
                 Member::where('platoon_id', $record->id)->update([
                     'platoon_id' => 0,
                     'squad_id' => 0,

--- a/app/Filament/Mod/Resources/PlatoonResource/RelationManagers/SquadsRelationManager.php
+++ b/app/Filament/Mod/Resources/PlatoonResource/RelationManagers/SquadsRelationManager.php
@@ -58,11 +58,9 @@ class SquadsRelationManager extends RelationManager
             ->actions([
                 Tables\Actions\EditAction::make()->url(fn (Model $record): string => SquadResource::getUrl('edit',
                     ['record' => $record])),
-                Tables\Actions\DeleteAction::make(),
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([
-                    //                    Tables\Actions\DeleteBulkAction::make(),
                 ]),
             ]);
     }

--- a/app/Filament/Mod/Resources/SquadResource.php
+++ b/app/Filament/Mod/Resources/SquadResource.php
@@ -63,7 +63,7 @@ class SquadResource extends Resource
                             Forms\Components\TextInput::make('logo')
                                 ->maxLength(191)
                                 ->default(null),
-                        ]),
+                        ])->columns(),
 
                         Forms\Components\Section::make('Leadership')->schema([
                             Select::make('leader_id')

--- a/app/Filament/Mod/Resources/SquadResource/Pages/EditSquad.php
+++ b/app/Filament/Mod/Resources/SquadResource/Pages/EditSquad.php
@@ -76,7 +76,9 @@ class EditSquad extends EditRecord
     protected function getHeaderActions(): array
     {
         return [
-            Actions\DeleteAction::make()->action(function ($record) {
+            Actions\DeleteAction::make()
+                ->modalDescription('Assigned members will be removed from this squad. Are you sure?')
+                ->action(function ($record) {
                 Member::where('squad_id', $record->id)->update([
                     'squad_id' => 0,
                 ]);


### PR DESCRIPTION
Avoid bulk delete of platoons. Also ensure division leaders assigned to their divisions can delete platoons. Add explicit verbiage about deletion.