### PR TITLE
Support award step for officer promotions (#513)

### DIFF
--- a/app/Enums/Rank.php
+++ b/app/Enums/Rank.php
@@ -117,6 +117,11 @@ enum Rank: int implements HasColor, HasLabel
         return $this->value > $previousRank->value;
     }
 
+    public function isOfficer(): bool
+    {
+        return $this->value >= self::LANCE_CORPORAL->value;
+    }
+
     public function routeNotificationForAdmin()
     {
         return config('app.aod.msgt-channel');

--- a/app/Filament/Mod/Resources/RankActionResource.php
+++ b/app/Filament/Mod/Resources/RankActionResource.php
@@ -9,15 +9,17 @@ use App\Filament\Mod\Resources\RankActionResource\RelationManagers\RequesterRela
 use App\Models\Member;
 use App\Models\RankAction;
 use Carbon\Carbon;
-use Filament\Forms;
 use Filament\Forms\Components\Checkbox;
+use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\Fieldset;
+use Filament\Forms\Components\Grid;
 use Filament\Forms\Components\Radio;
+use Filament\Forms\Components\RichEditor;
+use Filament\Forms\Components\Section;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
-use Filament\Forms\Components\View;
 use Filament\Forms\Components\ViewField;
 use Filament\Forms\Form;
-use Filament\Infolists\Infolist;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Filters\Filter;
@@ -50,41 +52,47 @@ class RankActionResource extends Resource
         return $form
             ->schema([
 
-                Forms\Components\Split::make([
-                    Forms\Components\Section::make('Rank Action Details')
-                        ->hiddenOn('create')
-                        ->schema([
-                            Forms\Components\Fieldset::make('Dates')->schema([
-                                Forms\Components\DateTimePicker::make('approved_at')
-                                    ->visible(fn ($record) => $record->approved_at)
-                                    ->readOnly(),
-                                Forms\Components\DateTimePicker::make('created_at')
-                                    ->label('Requested At')
-                                    ->readOnly(),
-                            ]),
-                            Select::make('rank')
-                                ->options(Rank::class)
-                                ->disabledOn('edit'),
+                Grid::make()
+                    ->schema([
+                        Fieldset::make('Metadata')
+                            ->schema([
+                                ViewField::make('status')
+                                    ->view('filament.forms.components.status-badge')
+                                    ->viewData(['record']),
+                                ViewField::make('type')
+                                    ->view('filament.forms.components.type-badge')
+                                    ->viewData(['record']),
+                            ])
+                            ->columnSpan(2),
 
-                            Forms\Components\RichEditor::make('justification')
-                                ->required()
-                                ->disabled(function ($record) {
-                                    return $record->requester_id !== auth()->user()->member_id;
-                                })
-                                ->columnSpanFull(),
-                        ]),
-                    Forms\Components\Fieldset::make('Metadata')
-                        ->schema([
-                            ViewField::make('status')
-                                ->view('filament.forms.components.status-badge')
-                                ->viewData(['record']),
-                            ViewField::make('type')
-                                ->view('filament.forms.components.type-badge')
-                                ->viewData(['record']),
-                        ])
-                        ->grow(false),
-
-                ])->columnSpanFull(),
+                        Section::make('Rank Action Details')
+                            ->hiddenOn('create')
+                            ->schema([
+                                Fieldset::make('Dates')->schema([
+                                    DateTimePicker::make('awarded_at')
+                                        ->visible(fn ($record) => $record->rank->value >= Rank::SERGEANT->value && $record->awarded_at)
+                                        ->label('Awarded At')
+                                        ->readOnly(),
+                                    DateTimePicker::make('approved_at')
+                                        ->visible(fn ($record) => $record->approved_at)
+                                        ->readOnly(),
+                                    DateTimePicker::make('created_at')
+                                        ->label('Requested At')
+                                        ->readOnly(),
+                                ])->columns(3),
+                                Select::make('rank')
+                                    ->options(Rank::class)
+                                    ->disabledOn('edit'),
+                                RichEditor::make('justification')
+                                    ->required()
+                                    ->disabled(function ($record) {
+                                        return $record->requester_id !== auth()->user()->member_id;
+                                    })
+                                    ->columnSpanFull(),
+                            ])
+                            ->columnSpan(2),
+                    ])
+                    ->columns(),
 
             ]);
     }

--- a/app/Filament/Mod/Resources/RankActionResource/Pages/EditRankAction.php
+++ b/app/Filament/Mod/Resources/RankActionResource/Pages/EditRankAction.php
@@ -6,13 +6,16 @@ use App\Enums\Rank;
 use App\Filament\Mod\Resources\RankActionResource;
 use App\Jobs\UpdateRankForMember;
 use App\Models\RankAction;
+use App\Notifications\DM\NotifyMemberOfficerPromotionPendingAcceptance;
 use App\Notifications\DM\NotifyMemberPromotionPendingAcceptance;
+use App\Notifications\DM\NotifyRequesterOfficerRankActionApproved;
 use App\Notifications\DM\NotifyRequesterRankActionDenied;
 use Filament\Actions;
 use Filament\Actions\Action;
 use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\Radio;
 use Filament\Forms\Components\Textarea;
+use Filament\Forms\Get;
 use Filament\Resources\Pages\EditRecord;
 use Parallax\FilamentComments\Actions\CommentsAction;
 
@@ -23,7 +26,7 @@ class EditRankAction extends EditRecord
     protected function mutateFormDataBeforeSave(array $data): array
     {
         // don't allow form changes
-        unset($data['status'], $data['type'], $data['approved_at'], $data['accepted_at']);
+        unset($data['status'], $data['type'], $data['approved_at'], $data['accepted_at'], $data['awarded_at']);
 
         return $data;
     }
@@ -37,16 +40,16 @@ class EditRankAction extends EditRecord
 
                 Actions\DeleteAction::make('delete')
                     ->label('Cancel Action')
-                    ->hidden(fn(RankAction $action) => !$action->actionable() && $action->member->division_id !== 0)
-                    ->visible(fn(RankAction $action) => auth()->user()->isDivisionLeader()
+                    ->hidden(fn (RankAction $action) => $action->member->division_id === 0)
+                    ->visible(fn (RankAction $action) => auth()->user()->isDivisionLeader()
                         || auth()->user()->isRole('admin')
-                        || auth()->id() == $action->requester_id
+                        || auth()->user()->member_id == $action->requester_id
                     )
                     ->requiresConfirmation(),
                 Actions\Action::make('deny')->label('Deny change')
                     ->color('warning')
-                    ->visible(fn(RankAction $action) => auth()->user()->canApproveOrDeny($action))
-                    ->hidden(fn($action) => !$action->getRecord()->actionable())
+                    ->visible(fn (RankAction $action) => auth()->user()->canApproveOrDeny($action))
+                    ->hidden(fn ($action) => ! $action->getRecord()->actionable())
                     ->requiresConfirmation()
                     ->modalHeading('Deny Rank Action')
                     ->modalDescription('Are you sure you want to deny this rank action? The requester will be notified.')
@@ -70,15 +73,27 @@ class EditRankAction extends EditRecord
                 Action::make('requeue')
                     ->label('Requeue Acceptance')
                     ->color('info')
-                    ->visible(fn($action) => auth()->user()->isDivisionLeader() || auth()->user()->isRole('admin'))
-                    ->hidden(fn($action) => ($record = $action->getRecord()) && (
-                            !$record->rank->isPromotion($record->member->rank)
-                            || !$record->approved_at
-                            || $record->approved_at->gt(now()->subMinutes(
-                                config('app.aod.rank.promotion_acceptance_mins')
-                            ))
-                            || $record->accepted_at
-                        ))
+                    ->visible(fn ($action) => auth()->user()->isDivisionLeader() || auth()->user()->isRole('admin'))
+                    ->hidden(function ($action) {
+                        $record = $action->getRecord();
+
+                        $rank = $record->rank;
+                        $memberRank = $record->member->rank;
+                        $approvedAt = $record->approved_at;
+                        $awardedAt = $record->awarded_at;
+                        $acceptedAt = $record->accepted_at;
+
+                        $isPromotion = $rank->isPromotion($memberRank);
+
+                        $promotionAcceptanceWindow = now()->subMinutes(config('app.aod.rank.promotion_acceptance_mins'));
+
+                        return ! $isPromotion
+                            || ! $approvedAt
+                            || ($rank->isOfficer() && ! $awardedAt)
+                            || ($rank->isOfficer() && $awardedAt->gt($promotionAcceptanceWindow))
+                            || ($approvedAt->gt($promotionAcceptanceWindow))
+                            || $acceptedAt;
+                    })
                     ->requiresConfirmation()
                     ->modalHeading('Requeue Acceptance')
                     ->modalDescription('Confirm that you wish to send the user a new promotion acceptance message')
@@ -92,8 +107,10 @@ class EditRankAction extends EditRecord
                         }
                     }),
 
-                Action::make('approve')
-                    ->label('Approve change')
+                Action::make('award')
+                    ->icon('heroicon-o-trophy')
+                    ->color('success')
+                    ->label('Award Rank Change')
                     ->closeModalByClickingAway(false)
                     ->form([
                         Radio::make('notification_type')
@@ -109,11 +126,64 @@ class EditRankAction extends EditRecord
                             ->minDate(now())
                             ->helperText('Timezone: America/New_York')
                             ->required()
-                            ->hidden(fn($get) => $get('notification_type') !== 'later'),
+                            ->hidden(fn ($get) => $get('notification_type') !== 'later'),
                     ])
+                    ->action(function (array $data, RankAction $action) {
+                        $action->award();
+                        $notification = new NotifyMemberOfficerPromotionPendingAcceptance($action);
+                        if ($data['notification_type'] === 'later') {
+                            $scheduledTime = \Carbon\Carbon::parse($data['scheduled_at']);
+                            $action->member->notify($notification->delay($scheduledTime));
+                        } else {
+                            $action->member->notify($notification);
+                        }
+                    })
+                    ->visible(fn (RankAction $action) => auth()->user()->member_id === $action->requester_id
+                        && $action->rank->isOfficer()
+                        && $action->approved_at
+                        && ! $action->awarded_at
+                    )
+                    ->requiresConfirmation()
+                    ->modalHeading(fn (Get $get, $record) => $record->rank->isOfficer()
+                        ? 'Award Officer Rank Change'
+                        : 'Award Rank Change')
+                    ->modalDescription('Member will receive a notification prompting them to accept or decline the rank change'),
+
+                Action::make('approve')
+                    ->label('Approve change')
+                    ->closeModalByClickingAway(false)
+                    ->form(function (Get $get, $record) {
+                        if ($record->rank->isOfficer()) {
+                            return [];
+                        }
+
+                        return [
+                            Radio::make('notification_type')
+                                ->label('Rank Acceptance Notification')
+                                ->options([
+                                    'now' => 'Send Now',
+                                    'later' => 'Schedule for Later',
+                                ])
+                                ->default('now')
+                                ->live(),
+                            DateTimePicker::make('scheduled_at')
+                                ->label('Schedule Notification')
+                                ->minDate(now())
+                                ->helperText('Timezone: America/New_York')
+                                ->required()
+                                ->hidden(fn ($get) => $get('notification_type') !== 'later'),
+                        ];
+                    })
                     ->action(function (array $data, RankAction $action) {
                         if ($action->rank->isPromotion($action->member->rank)) {
                             $action->approve();
+
+                            if ($action->rank->isOfficer($action->member->rank)) {
+                                // MCO ranks require additional processing
+                                $action->requester->notify(new NotifyRequesterOfficerRankActionApproved($action));
+
+                                return;
+                            }
 
                             $notification = new NotifyMemberPromotionPendingAcceptance($action);
                             if ($data['notification_type'] === 'later') {
@@ -127,20 +197,28 @@ class EditRankAction extends EditRecord
                             UpdateRankForMember::dispatch($action);
                         }
                     })
-                    ->visible(fn(RankAction $action) => auth()->user()->canApproveOrDeny($action))
-                    ->hidden(fn($action) => !$action->getRecord()->actionable())
+                    ->visible(fn (RankAction $action) => auth()->user()->canApproveOrDeny($action))
+                    ->hidden(fn ($action) => ! $action->getRecord()->actionable())
                     ->requiresConfirmation()
-                    ->modalHeading('Approve Rank Change')
-                    ->modalDescription('Member will receive a notification prompting them to accept or decline the rank change'),
+                    ->modalHeading(fn (Get $get, $record) => $record->rank->isOfficer()
+                        ? 'Approve Officer Rank Change'
+                        : 'Approve Rank Change')
+                    ->modalDescription(function (Get $get, $record) {
+                        if ($record->rank->isOfficer()) {
+                            return 'The requester will be notified that the officer promotion was approved. They will need to coordinate with the member to award the promotion.';
+                        }
+
+                        return 'Member will receive a notification prompting them to accept or decline the rank change';
+                    }),
 
                 Action::make('approve_with_force')
                     ->color('warning')
                     ->requiresConfirmation()
                     ->visible(
-                        fn(RankAction $action) => auth()->user()->canApproveOrDeny($action)
+                        fn (RankAction $action) => auth()->user()->canApproveOrDeny($action)
                             && $action->rank->value <= Rank::PRIVATE_FIRST_CLASS->value
                     )
-                    ->hidden(fn(RankAction $action) => $action->accepted_at && !$action->actionable())
+                    ->hidden(fn (RankAction $action) => $action->accepted_at && ! $action->actionable())
                     ->action(function (RankAction $action) {
                         $action->approveAndAccept();
                         UpdateRankForMember::dispatch($action);

--- a/app/Http/Controllers/Auth/AuthenticatesWithAOD.php
+++ b/app/Http/Controllers/Auth/AuthenticatesWithAOD.php
@@ -6,6 +6,7 @@ use Exception;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 
 trait AuthenticatesWithAOD
 {

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -6,7 +6,7 @@ use App\AOD\ClanForumPermissions;
 use App\Http\Controllers\Controller;
 use App\Models\Member;
 use App\Models\User;
-use Auth;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Foundation\Auth\ThrottlesLogins;

--- a/app/Models/RankAction.php
+++ b/app/Models/RankAction.php
@@ -18,6 +18,7 @@ class RankAction extends Model
         'rank' => Rank::class,
         'approved_at' => 'datetime',
         'accepted_at' => 'datetime',
+        'awarded_at' => 'datetime',
         'declined_at' => 'datetime',
     ];
 
@@ -56,11 +57,23 @@ class RankAction extends Model
         return $this;
     }
 
-    public function approveAndAccept()
+    public function award()
     {
         $this->update([
-            'approved_at' => now(),
-            'accepted_at' => now(),
+            'awarded_at' => now(),
+        ]);
+
+        return $this;
+    }
+
+    public function approveAndAccept()
+    {
+        $now = now();
+
+        $this->update([
+            'approved_at' => $now,
+            'accepted_at' => $now,
+            'awarded_at' => $now,
         ]);
 
         return $this;

--- a/app/Notifications/DM/NotifyMemberOfficerPromotionPendingAcceptance.php
+++ b/app/Notifications/DM/NotifyMemberOfficerPromotionPendingAcceptance.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Notifications\DM;
+
+use App\Channels\BotChannel;
+use App\Channels\Messages\BotDMMessage;
+use App\Models\RankAction;
+use App\Notifications\Channel\NotifyDivisionFailedPromotionAcceptance;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Notification;
+use Illuminate\Support\Facades\URL;
+
+class NotifyMemberOfficerPromotionPendingAcceptance extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(private readonly RankAction $action) {}
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function via($notifiable)
+    {
+        return [BotChannel::class];
+    }
+
+    public function failed(): void
+    {
+        $this->action->member->division->notify(
+            new NotifyDivisionFailedPromotionAcceptance($this->action->member)
+        );
+    }
+
+    public function toBot($notifiable): array
+    {
+        $route = URL::temporarySignedRoute('promotion.confirm', now()->addMinutes(
+            config('app.aod.rank.promotion_acceptance_mins')
+        ), [
+            $notifiable->clan_id,
+            $this->action,
+        ]);
+
+        \Log::info($route);
+
+        return (new BotDMMessage)
+            ->to($notifiable->discord_id)
+            ->message(sprintf(
+                "**Congratulations on your promotion!**! Visit the following URL to accept or decline this promotion!\r\n\r\n[View Promotion](%s)",
+                $route
+            ))->send();
+    }
+}

--- a/app/Notifications/DM/NotifyRequesterOfficerRankActionApproved.php
+++ b/app/Notifications/DM/NotifyRequesterOfficerRankActionApproved.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Notifications\DM;
+
+use App\Channels\BotChannel;
+use App\Channels\Messages\BotDMMessage;
+use App\Models\RankAction;
+use App\Traits\RetryableNotification;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Notification;
+
+class NotifyRequesterOfficerRankActionApproved extends Notification implements ShouldQueue
+{
+    use Queueable, RetryableNotification;
+
+    public function __construct(
+        private readonly RankAction $action,
+    ) {}
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function via($notifiable)
+    {
+        return [BotChannel::class];
+    }
+
+    /**
+     * @return array
+     *
+     * @throws \Exception
+     */
+    public function toBot($notifiable)
+    {
+        return (new BotDMMessage)
+            ->to($notifiable->discord_id)
+            ->message(sprintf(
+                '*Action required*: An officer rank action you requested [%s to %s] was approved. Please coordinate with the member to award the promotion.',
+                $this->action->member->name,
+                $this->action->rank->getLabel(),
+            ))
+            ->send();
+    }
+}

--- a/resources/views/errors/500.blade.php
+++ b/resources/views/errors/500.blade.php
@@ -20,10 +20,10 @@
 
         <div class="panel panel-filled">
             <div class="panel-body">
-                <p>It looks like something went terribly wrong.</p>
+                <p>It looks like something went terribly wrong. Report this issue to the clan admins! The error you
+                    found is:</p>
 
-                <p>Report this issue to the clan admins! The error you found is: <code>{{ $exception->getMessage()
-                }}</code></p>
+                <p><code>{{ $exception->getMessage()}}</code></p>
             </div>
         </div>
 

--- a/resources/views/filament/forms/components/status-badge.blade.php
+++ b/resources/views/filament/forms/components/status-badge.blade.php
@@ -17,7 +17,13 @@
         $title = 'Waiting for Approval';
         $color = 'warning';
         $icon = 'heroicon-s-clock'; // ⏳
-    } elseif (!is_null($record?->approved_at) && is_null($record?->accepted_at)) {
+     } elseif ($record?->rank->isOfficer() && is_null($record?->awarded_at)) {
+        // Pending award
+        $status = 'Awaiting Award';
+        $title = 'Requester action required';
+        $color = 'primary';
+        $icon = 'heroicon-s-clock'; // ⏳
+    } elseif (!is_null($record?->approved_at || $record?->awarded_at) && is_null($record?->accepted_at)) {
         // Pending acceptance
         $status = 'Acceptance';
         $title = 'Waiting for Member Acceptance';


### PR DESCRIPTION
* Implement officer rank change step
  * Officer promotion rank actions will notify the requester upon approval that the promotion can be awarded
  * Awarding rank behaves the same as approving non-officer ranks - the recipient must accept or decline
* Fix bug prevent cancellation of rank actions
  * Rank actions can now be cancelled all the way up to the point of member separation
* Clean up exception page and provide better error reporting to the end user