### PR TITLE
Urlencode handles when used in a URL

### DIFF
--- a/app/Models/Handle/HasCustomAttributes.php
+++ b/app/Models/Handle/HasCustomAttributes.php
@@ -6,6 +6,6 @@ trait HasCustomAttributes
 {
     public function getFullUrlAttribute()
     {
-        return $this->url . $this->pivot->value;
+        return $this->url . urlencode($this->pivot->value);
     }
 }

--- a/resources/views/member/partials/handle-link.blade.php
+++ b/resources/views/member/partials/handle-link.blade.php
@@ -1,11 +1,11 @@
-<a href="{{ $handle->url }}{{ $handle->pivot->value }}"
+<a href="{{ $handle->full_url }}"
    target="_blank" class="panel panel-filled panel-c-success">
     <div class="panel-body ">
         <small class="c-white slight text-uppercase">
             {{ $handle->label }}
         </small>
         <span class="pull-right"><i class="fa fa-link"></i></span>
-        <br />
+        <br/>
         <span class="text-uppercase">{{ $handle->pivot->value }}</span>
     </div>
 </a>


### PR DESCRIPTION
Some handles support special characters such as `#` which results in a non-functional URL.