### PR TITLE
Make squad names required

### DIFF
--- a/app/Filament/Mod/Resources/PlatoonResource/RelationManagers/SquadsRelationManager.php
+++ b/app/Filament/Mod/Resources/PlatoonResource/RelationManagers/SquadsRelationManager.php
@@ -18,8 +18,8 @@ class SquadsRelationManager extends RelationManager
     {
         return $form->schema([
             Forms\Components\TextInput::make('name')
-                ->maxLength(255)
-                ->default(null),
+                ->required()
+                ->maxLength(255),
             Forms\Components\TextInput::make('logo')
                 ->maxLength(191)
                 ->placeholder('https://')

--- a/app/Filament/Mod/Resources/SquadResource.php
+++ b/app/Filament/Mod/Resources/SquadResource.php
@@ -31,8 +31,8 @@ class SquadResource extends Resource
 
                         Forms\Components\Section::make('Basic Info')->schema([
                             Forms\Components\TextInput::make('name')
-                                ->maxLength(255)
-                                ->default(null),
+                                ->required()
+                                ->maxLength(255),
                             Forms\Components\TextInput::make('logo')
                                 ->maxLength(191)
                                 ->default(null),


### PR DESCRIPTION
Make `name` a required field when creating or editing a squad. Null squad names break dropdowns and could result in other unexpected behavior. 