### PR TITLE
Release cleanup

### DIFF
--- a/app/Filament/Actions/Members/CleanupUnassignedLeadersAction.php
+++ b/app/Filament/Actions/Members/CleanupUnassignedLeadersAction.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace App\Filament\Actions\Members;
+
+use App\Models\Member;
+use Filament\Actions\Action;
+use Filament\Forms\Components\Placeholder;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Get;
+use Filament\Notifications\Notification;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\HtmlString;
+
+class CleanupUnassignedLeadersAction extends Action
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->label('Unassigned leaders')
+            ->icon('heroicon-o-wrench-screwdriver')
+            ->color('warning')
+            ->requiresConfirmation()
+            ->form([
+
+                Placeholder::make('preview')
+                    ->label('Preview Change')
+                    ->content(function (Get $get): HtmlString {
+                        $rule = $get('rule');
+
+                        $c2 = in_array($rule, ['squad_pos2', 'both'], true)
+                            ? \App\Models\Member::unassignedSquadLeaders()->count()
+                            : 0;
+
+                        $c3 = in_array($rule, ['platoon_pos3', 'both'], true)
+                            ? \App\Models\Member::unassignedPlatoonLeaders()->count()
+                            : 0;
+
+                        if (max($c2, $c3) === 0 && $rule !== null) {
+                            return new HtmlString('No members will be affected.');
+                        }
+
+                        $html = match ($rule) {
+                            'squad_pos2' => "Will update <b>{$c2}</b> unassigned squad leaders",
+                            'platoon_pos3' => "Will update <b>{$c3}</b> unassigned platoon leaders.",
+                            'both' => "Will update: <br /><b>{$c2}</b> unassigned squad leaders <br /><b>{$c3}</b> unassigned platoon leaders.",
+                            default => '<span class="text-gray-500">Select a rule to see how many members will be affected.</span>',
+                        };
+
+                        return new HtmlString($html);
+                    }),
+
+                Select::make('rule')
+                    ->label('Which rule to run?')
+                    ->options([
+                        'squad_pos2' => 'Unassigned squad leaders',
+                        'platoon_pos3' => 'Unassigned platoon leaders',
+                        'both' => 'Run both rules',
+                    ])
+                    ->required()
+                    ->reactive()
+                    ->native(false),
+            ])
+            ->modalHeading('Confirm maintenance action')
+            ->modalDescription('Unassigned leader cleanup')
+            ->action(function (array $data): void {
+                $rule = $data['rule'] ?? 'squad_pos2';
+
+                $updated2 = 0;
+                $updated3 = 0;
+
+                DB::transaction(function () use ($rule, &$updated2, &$updated3) {
+                    if ($rule === 'squad_pos2' || $rule === 'both') {
+                        $updated2 = Member::unassignedSquadLeaders()->update(['position' => 1]);
+                    }
+
+                    if ($rule === 'platoon_pos3' || $rule === 'both') {
+                        $updated3 = Member::unassignedPlatoonLeaders()->update(['position' => 1]);
+                    }
+                });
+
+                $summary = match ($rule) {
+                    'squad_pos2' => "Updated {$updated2} member(s) from position 2 → 1.",
+                    'platoon_pos3' => "Updated {$updated3} member(s) from position 3 → 1.",
+                    'both' => "Updated {$updated2} member(s) (pos=2 → 1) and {$updated3} member(s) (pos=3 → 1).",
+                    default => 'No changes performed.',
+                };
+
+                Notification::make()
+                    ->title('Maintenance action completed')
+                    ->body($summary)
+                    ->success()
+                    ->send();
+            });
+    }
+
+    /**
+     * Compute current counts for the live modal preview.
+     *
+     * @return array{int,int} [pos2NonSquadLeaders, pos3NonPlatoonLeaders]
+     */
+    protected function counts(): array
+    {
+        $c2 = Member::unassignedSquadLeaders()->count();
+        $c3 = Member::unassignedPlatoonLeaders()->count();
+        return [$c2, $c3];
+    }
+
+    public static function getDefaultName(): ?string
+    {
+        return 'combinedDemotions';
+    }
+}

--- a/app/Filament/Admin/Resources/HandleResource.php
+++ b/app/Filament/Admin/Resources/HandleResource.php
@@ -28,10 +28,11 @@ class HandleResource extends Resource
                 Forms\Components\TextInput::make('type')
                     ->required()
                     ->maxLength(255),
-                Forms\Components\TextInput::make('comments')
+                Forms\Components\Textarea::make('comments')
                     ->maxLength(255)
+                    ->columnSpanFull()
                     ->default(null),
-                Forms\Components\Textarea::make('url')
+                Forms\Components\TextInput::make('url')
                     ->columnSpanFull(),
             ]);
     }

--- a/app/Filament/Admin/Resources/MemberResource/Pages/ListMembers.php
+++ b/app/Filament/Admin/Resources/MemberResource/Pages/ListMembers.php
@@ -2,9 +2,11 @@
 
 namespace App\Filament\Admin\Resources\MemberResource\Pages;
 
+use App\Filament\Actions\Members\CleanupUnassignedLeadersAction;
 use App\Filament\Admin\Resources\MemberResource;
 use Filament\Actions;
 use Filament\Resources\Pages\ListRecords;
+use Filament\Support\Enums\ActionSize;
 
 class ListMembers extends ListRecords
 {
@@ -14,6 +16,13 @@ class ListMembers extends ListRecords
     {
         return [
             Actions\CreateAction::make(),
+
+            Actions\ActionGroup::make([
+                CleanupUnassignedLeadersAction::make(),
+            ])->label('Cleanup Actions')
+                ->color('primary')
+                ->button()
+                ->icon('heroicon-o-wrench-screwdriver'),
         ];
     }
 }

--- a/app/Models/Member.php
+++ b/app/Models/Member.php
@@ -120,6 +120,24 @@ class Member extends Model
         ]);
     }
 
+    public function scopeUnassignedSquadLeaders($query)
+    {
+        return $query
+            ->where('position', 2)
+            ->whereNotIn('clan_id', function ($q) {
+                $q->select('leader_id')->from('squads')->whereNotNull('leader_id');
+            });
+    }
+
+    public function scopeUnassignedPlatoonLeaders($query)
+    {
+        return $query
+            ->where('position', 3)
+            ->whereNotIn('clan_id', function ($q) {
+                $q->select('leader_id')->from('platoons')->whereNotNull('leader_id');
+            });
+    }
+
     /**
      * Handle Staff Sergeant assignments
      * division/.

--- a/app/Models/Member.php
+++ b/app/Models/Member.php
@@ -123,7 +123,7 @@ class Member extends Model
     public function scopeUnassignedSquadLeaders($query)
     {
         return $query
-            ->where('position', 2)
+            ->where('position', Position::SQUAD_LEADER)
             ->whereNotIn('clan_id', function ($q) {
                 $q->select('leader_id')->from('squads')->whereNotNull('leader_id');
             });
@@ -132,7 +132,7 @@ class Member extends Model
     public function scopeUnassignedPlatoonLeaders($query)
     {
         return $query
-            ->where('position', 3)
+            ->where('position', Position::PLATOON_LEADER)
             ->whereNotIn('clan_id', function ($q) {
                 $q->select('leader_id')->from('platoons')->whereNotNull('leader_id');
             });


### PR DESCRIPTION
Minor improvements to the handles resource to allow for more verbose comments. We'll add these to the ingame handles form to make it easier to understand where they should come from. It should also be more obvious when deeplinking is possible.

Also adds an admin cleanup action group, and an action for correcting members who have `Position::SQUAD_LEADER` or `Position::PLATOON_LEADER` but aren't actually assigned as leaders of a squad or platoon