### PR TITLE
Revamp promotions, improve retention reports

### DIFF
--- a/app/Http/Controllers/Division/ReportController.php
+++ b/app/Http/Controllers/Division/ReportController.php
@@ -2,10 +2,16 @@
 
 namespace App\Http\Controllers\Division;
 
+use App\Models\Activity;
 use App\Models\Division;
+use App\Models\RankAction;
+use App\Models\User;
 use App\Repositories\DivisionRepository;
 use App\Repositories\MemberRepository;
 use Illuminate\Contracts\View\Factory;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
 use Illuminate\View\View;
 
 class ReportController extends \App\Http\Controllers\Controller
@@ -23,33 +29,74 @@ class ReportController extends \App\Http\Controllers\Controller
      */
     public function retentionReport(Division $division)
     {
+        $defaultStart = now()->subMonthsNoOverflow(6)->startOfMonth();
+        $defaultEnd   = now()->endOfMonth();
+
+        $start = request()->filled('start')
+            ? Carbon::parse(request('start'))->startOfDay()
+            : $defaultStart;
+
+        $end = request()->filled('end')
+            ? Carbon::parse(request('end'))->endOfDay()
+            : $defaultEnd;
+
         $range = [
             'start' => request('start') ?? now()->subMonths(6)->startOfMonth()->format('Y-m-d'),
             'end' => request('end') ?? now()->endOfMonth()->format('Y-m-d'),
         ];
-        $activity = collect(\App\Models\Activity::whereName('recruited_member')->whereDivisionId($division->id)->whereBetween('created_at',
-            [
-                $range['start'], $range['end'],
-            ])->with('user.member')->get())->groupBy('user_id');
-        $members = $activity->map(function ($item) {
-            if ($item->first()->user) {
-                return ['recruits' => \count($item), 'member' => $item->first()->user->member];
-            }
-        })->sortByDesc('recruits');
-        $totalRecruitCount = $members->map(function ($item) {
-            if ($item !== null) {
-                return $item['recruits'];
-            }
-        })->sum();
-        $recruits = $this->division->recruitsLast6Months($division->id, $range['start'])->map(fn ($record
-        ) => [$record->date, $record->recruits]);
-        $removals = $this->division->removalsLast6Months($division->id, $range['start'])->map(fn ($record
-        ) => [$record->date, $record->removals]);
-        $population = $this->division->populationLast6Months($division->id, $range['start'])->map(fn ($record
-        ) => [$record->date, $record->count]);
 
-        return view('division.reports.retention-report',
-            compact('division', 'members', 'totalRecruitCount', 'population', 'range', 'recruits', 'removals'));
+        $activityCounts = \App\Models\Activity::query()
+            ->where('name', 'recruited_member')
+            ->where('division_id', $division->id)
+            ->whereBetween('created_at', [$start, $end])
+            ->select('user_id', \DB::raw('COUNT(*) as recruits'))
+            ->groupBy('user_id')
+            ->get();
+
+        $users = User::query()
+            ->with('member')
+            ->whereIn('id', $activityCounts->pluck('user_id'))
+            ->get()
+            ->keyBy('id');
+
+        $members = $activityCounts
+            ->map(function ($row) use ($users) {
+                $user = $users->get($row->user_id);
+                if (!$user || !$user->member) {
+                    return null;
+                }
+                return [
+                    'recruits' => (int) $row->recruits,
+                    'member'   => $user->member,
+                ];
+            })
+            ->filter()
+            ->sortByDesc('recruits')
+            ->values();
+
+        $totalRecruitCount = (int) $activityCounts->sum('recruits');
+
+        $recruits = $this->division
+            ->recruitsLast6Months($division->id, $range['start'], $range['end'] ?? null)
+            ->map(fn ($r) => [$r->date, $r->recruits]);
+
+        $removals = $this->division
+            ->removalsLast6Months($division->id, $range['start'], $range['end'] ?? null)
+            ->map(fn ($r) => [$r->date, $r->removals]);
+
+        $population = $this->division
+            ->populationLast6Months($division->id, $range['start'], $range['end'] ?? null)
+            ->map(fn ($r) => [$r->date, $r->count]);
+
+        return view('division.reports.retention-report', compact(
+            'division',
+            'members',
+            'totalRecruitCount',
+            'population',
+            'range',
+            'recruits',
+            'removals'
+        ));
     }
 
     /**
@@ -66,31 +113,6 @@ class ReportController extends \App\Http\Controllers\Controller
         }
 
         return view('division.reports.ingame-report', compact('division', 'data'));
-    }
-
-    /**
-     * @param  null  $month
-     * @param  null  $year
-     * @return Factory|View
-     */
-    public function promotionsReport(MemberRepository $repository, $division, $month = null, $year = null)
-    {
-        try {
-            $members = $this->getMemberPromotions($division, $month, $year);
-        } catch (\Exception $exception) {
-            $members = collect([]);
-        }
-
-        $ranks = $members->pluck('rank')->unique()->map(fn ($rank) => $rank->getAbbreviation());
-
-        $counts = $members->groupBy('rank')->each(function ($rank) {
-            $rank->count = \count($rank);
-        })->pluck('count');
-
-        $promotionPeriods = $repository->promotionPeriods();
-
-        return view('division.reports.promotions',
-            compact('members', 'division', 'promotionPeriods', 'year', 'month', 'ranks', 'counts'));
     }
 
     /**
@@ -144,17 +166,103 @@ class ReportController extends \App\Http\Controllers\Controller
         ));
     }
 
-    /**
-     * @return mixed
-     */
-    private function getMemberPromotions($division, $month, $year)
-    {
-        $dates = $month && $year ? [
-            \Carbon\Carbon::parse($month . " {$year}")->startOfMonth(),
-            \Carbon\Carbon::parse($month . " {$year}")->endOfMonth(),
-        ] : [\Carbon\Carbon::now()->startOfMonth(), \Carbon\Carbon::now()->endOfMonth()];
+    public function promotionsReport(
+        Request $request,
+        MemberRepository $repository,
+        $division,
+        $month = null,
+        $year = null
+    ) {
+        $month = $month ?? $request->query('month');
+        $year = $year ?? $request->query('year');
 
-        return $division->members()->whereBetween('last_promoted_at',
-            $dates)->orderByDesc('rank')->get();
+        try {
+            $promotions = $this->getDivisionPromotions($division, $month, $year);
+        } catch (\Throwable $e) {
+            $promotions = collect();
+        }
+
+        $ranks = $promotions
+            ->pluck('rank')
+            ->filter()
+            ->unique()
+            ->map(fn ($r) => method_exists($r, 'abbreviation') ? $r->abbreviation()
+                : (method_exists($r, 'getAbbreviation') ? $r->getAbbreviation()
+                    : ($r->name ?? (string) $r)))
+            ->values();
+
+        $counts = $promotions->groupBy('rank')->map->count()->values();
+
+        $promotionPeriods = $this->promotionPeriodsFromActions($division);
+
+        return view('division.reports.promotions', [
+            'promotions' => $promotions,
+            'division' => $division,
+            'promotionPeriods' => $promotionPeriods,
+            'year' => $year,
+            'month' => $month,
+            'ranks' => $ranks,
+            'counts' => $counts,
+        ]);
+    }
+
+    private function promotionPeriodsFromActions($division)
+    {
+        $base = RankAction::query()
+            ->whereNotNull('approved_at')
+            ->whereHas('member', fn ($q) => $q->where('division_id', $division->id));
+
+        $rows = $base->get(['approved_at'])
+            ->map(fn ($r) => [
+                'y' => (int) $r->approved_at->format('Y'),
+                'm' => (int) $r->approved_at->format('n'),
+            ])
+            ->unique(fn ($r) => $r['y'] . '-' . $r['m'])
+            ->sortByDesc(fn ($r) => sprintf('%04d-%02d', $r['y'], $r['m']))
+            ->values();
+
+        return $rows->map(function ($r) {
+            $y = is_array($r) ? $r['y'] : (int) $r->y;
+            $m = is_array($r) ? $r['m'] : (int) $r->m;
+
+            return [
+                'year' => $y,
+                'month' => $m,
+                'label' => \Carbon::createFromDate($y, $m, 1)->format('F Y'),
+                'key' => sprintf('%04d-%02d', $y, $m),
+            ];
+        })->values();
+    }
+
+    private function getDivisionPromotions($division, $month, $year): Collection
+    {
+        [$start, $end] = $this->resolveMonthWindow($month, $year);
+
+        return RankAction::query()
+            ->with('member')
+            ->whereNotNull('approved_at')
+            ->whereBetween('approved_at', [$start, $end])
+            ->whereHas('member', fn ($q) => $q->where('division_id', $division->id))
+            ->orderByDesc('approved_at')
+            ->get();
+    }
+
+    private function resolveMonthWindow($month, $year): array
+    {
+        if ($month && $year) {
+            try {
+                $start = \ctype_digit((string) $month)
+                    ? Carbon::createFromDate((int) $year, (int) $month, 1)->startOfMonth()
+                    : Carbon::parse("first day of {$month} {$year}")->startOfDay()->startOfMonth();
+            } catch (\Throwable $e) {
+                $start = now()->startOfMonth();
+            }
+        } else {
+            $start = now()->startOfMonth();
+        }
+
+        $end = (clone $start)->endOfMonth();
+
+        return [$start, $end];
     }
 }

--- a/app/Repositories/MemberRepository.php
+++ b/app/Repositories/MemberRepository.php
@@ -3,28 +3,11 @@
 namespace App\Repositories;
 
 use App\Models\Member;
-use Illuminate\Support\Facades\DB;
 
 class MemberRepository
 {
     public function search($name)
     {
         return Member::where('name', 'LIKE', "%{$name}%")->get();
-    }
-
-    /**
-     * Returns promotion periods for members in the
-     * form of year and month.
-     *
-     * @return static
-     */
-    public function promotionPeriods()
-    {
-        return collect(DB::select("
-            SELECT Year(last_promoted_at) AS year, MONTHNAME(STR_TO_DATE(Month(last_promoted_at), '%m')) AS month
-            FROM members 
-            GROUP BY Year(last_promoted_at), Month(last_promoted_at)
-            ORDER BY year DESC
-        "))->filter(fn ($values) => $values->month !== null);
     }
 }

--- a/resources/views/division/partials/filter-promotions.blade.php
+++ b/resources/views/division/partials/filter-promotions.blade.php
@@ -1,14 +1,29 @@
-<div class="panel panel-filled panel-c-info">
-    <div class="panel-body">
-        <label for="promotion-periods">Filter by promotion period</label>
-        <select name="promotion-periods" id="promotion-periods" class="form-control"
-                onChange="top.location.href=this.options[this.selectedIndex].value;">
-            <option value="" disabled selected>Select a period</option>
-            @foreach ($promotionPeriods as $period)
-                <option value="{{ route('division.promotions', [$division->slug, $period->month, $period->year]) }}">
-                    {{ $period->month }} {{ $period->year }}
+<form method="GET" action="{{ route('division.promotions', $division) }}" class="form-inline m-b">
+    <div class="form-group">
+        <label for="period" class="m-r-sm">Period</label>
+        <select name="period" id="period" class="form-control">
+            @foreach ($promotionPeriods as $p)
+                <option value="{{ $p['year'] }}-{{ str_pad($p['month'], 2, '0', STR_PAD_LEFT) }}"
+                        @selected(
+                            (request('year') == $p['year'] && request('month') == $p['month'])
+                            || ((int)($year ?? 0) === $p['year'] && (int)($month ?? 0) === $p['month'])
+                        )>
+                    {{ $p['label'] }}
                 </option>
             @endforeach
         </select>
     </div>
-</div>
+
+    <input type="hidden" name="year"  id="yearField"  value="{{ (int)($year ?? 0) }}">
+    <input type="hidden" name="month" id="monthField" value="{{ (int)($month ?? 0) }}">
+
+    <button type="submit" class="btn btn-primary m-l-sm">Apply</button>
+</form>
+
+<script>
+    document.getElementById('period')?.addEventListener('change', function () {
+        const [yr, mo] = this.value.split('-');
+        document.getElementById('yearField').value  = parseInt(yr, 10);
+        document.getElementById('monthField').value = parseInt(mo, 10);
+    });
+</script>

--- a/resources/views/division/partials/member-promotions.blade.php
+++ b/resources/views/division/partials/member-promotions.blade.php
@@ -2,25 +2,28 @@
     <div class="col-md-9">
         <div class="panel panel-filled">
             <div class="panel-body">
-                @foreach ($members->groupBy('rank.name') as $rank=>$rankGroup)
+                @foreach ($promotions->groupBy(fn ($a) => $a->rank?->name ?? 'Unspecified') as $rankName => $group)
                     <div class="panel m-b-none">
                         <div class="panel-body">
                             <table class="table table-condensed">
                                 <thead>
                                 <tr>
-                                    <th>{{ $rank }}</th>
+                                    <th>{{ $rankName }}</th>
+                                    <th class="text-right text-muted slight">Approved At</th>
                                 </tr>
                                 </thead>
                                 <tbody>
-                                @foreach ($rankGroup as $member)
+                                @foreach ($group as $action)
                                     <tr>
-                                        <td>{{ $member->name }}</td>
-                                        <td class="text-right text-muted slight">{{ $member->last_promoted_at }}</td>
+                                        <td>{{ $action->member?->name }}</td>
+                                        <td class="text-right text-muted slight">
+                                            {{ optional($action->approved_at)->toDateTimeString() }}
+                                        </td>
                                     </tr>
                                 @endforeach
                                 <tr>
                                     <td class="text-accent">Total</td>
-                                    <td class="text-accent text-right">{{ $rankGroup->count() }}</td>
+                                    <td class="text-accent text-right">{{ $group->count() }}</td>
                                 </tr>
                                 </tbody>
                             </table>
@@ -35,7 +38,7 @@
         <div class="panel panel-filled">
             <div class="panel-body">
                 <canvas class="promotions-chart"
-                        data-labels="{{ json_encode($ranks->values()) }}"
+                        data-labels="{{ json_encode($ranks) }}"
                         data-values="{{ json_encode($counts) }}"
                 ></canvas>
             </div>
@@ -47,8 +50,8 @@
 
                 <pre id="bb-code-promos">@include('division.partials.promo-bb-code')</pre>
 
-                <button data-clipboard-target="#bb-code-promos" class="copy-to-clipboard btn-success btn"><i
-                            class="fa fa-clone"></i> Copy BB-Code
+                <button data-clipboard-target="#bb-code-promos" class="copy-to-clipboard btn-success btn">
+                    <i class="fa fa-clone"></i> Copy BB-Code
                 </button>
             </div>
         </div>

--- a/resources/views/division/partials/promo-bb-code.blade.php
+++ b/resources/views/division/partials/promo-bb-code.blade.php
@@ -1,2 +1,9 @@
-@foreach ($members->groupBy('rank.name') as $rank=>$members)[b]{{ $rank }}[/b][list]@foreach ($members as $member)[*]{{ $member->name }}@endforeach[/list]
+@foreach ($promotions->groupBy(fn ($p) => $p->rank?->name ?? 'Unspecified') as $rank => $actions)
+    [b]{{ strtoupper($rank) }}[/b]
+    [list]
+    @foreach ($actions as $action)
+        [*]{{ $action->member?->name }}
+    @endforeach
+[/list]
+
 @endforeach

--- a/resources/views/division/reports/promotions.blade.php
+++ b/resources/views/division/reports/promotions.blade.php
@@ -18,16 +18,16 @@
 
         @include ('division.partials.filter-promotions')
 
-        @if ($year && $month && count($members))
-            <h4>{{ $month }} {{ $year }} Promotions</h4>
+        @if ($year && $month && $promotions->count())
+            <h4>{{ \Carbon\Carbon::createFromDate((int)$year, (int)$month, 1)->format('F Y') }} Promotions</h4>
             <hr />
-        @elseif (count($members))
-            <h4>{{ Carbon::now()->format('F Y') }} Promotions</h4>
+        @elseif ($promotions->count())
+            <h4>{{ \Carbon\Carbon::now()->format('F Y') }} Promotions</h4>
             <hr />
         @endif
 
-        @if (count($members))
-            @include ('division.partials.member-promotions')
+        @if ($promotions->count())
+            @include ('division.partials.member-promotions', ['promotions' => $promotions])
         @else
             <p>No promotions found.</p>
         @endif
@@ -38,4 +38,3 @@
 @section('footer_scripts')
     <script src="{!! asset('/js/division.js?v=2.2') !!}"></script>
 @endsection
-


### PR DESCRIPTION
This PR updates the promotion report to list promotions that happened at a given time rather than just those members who were last promoted that month. We don't currently record the division the promotion occurred in, so divisions will see historical promotions for any member currently assigned to them, even if the promotion happened in a previous division.

Also makes some improvements to the retention report, aggregating counts in SQL rather than PHP for performance, improves `endDate` handling for chart series