### PR TITLE
Add trash filter for restoration

### DIFF
--- a/app/Filament/Admin/Resources/DivisionResource.php
+++ b/app/Filament/Admin/Resources/DivisionResource.php
@@ -200,6 +200,8 @@ class DivisionResource extends Resource
                     ->query(fn (Builder $query): Builder => $query->where('active', true))
                     ->label('Hide inactive')
                     ->default(),
+
+                TrashedFilter::make(),
             ])
             ->actions([
                 Tables\Actions\EditAction::make(),

--- a/app/Filament/Admin/Resources/NoteResource.php
+++ b/app/Filament/Admin/Resources/NoteResource.php
@@ -69,7 +69,7 @@ class NoteResource extends Resource
                     ->toggleable(isToggledHiddenByDefault: true),
             ])
             ->filters([
-                //
+                TrashedFilter::make(),
             ])
             ->actions([
                 Tables\Actions\EditAction::make(),


### PR DESCRIPTION
Adds a `trashed` filter to admin resources to enable restoring deleted models since many/all models leverage soft deletion.