### PR TITLE
Allow division-set metadata

### DIFF
--- a/app/Filament/Mod/Resources/DivisionResource.php
+++ b/app/Filament/Mod/Resources/DivisionResource.php
@@ -222,6 +222,10 @@ class DivisionResource extends Resource
                                 // 'attachFiles',
                             ])
                             ->columnSpanFull(),
+                        Forms\Components\Textarea::make('meta_description')
+                            ->maxLength(100)
+                            ->statePath('settings.meta_description')
+                            ->helperText('60-100 character summary of division for SEO purposes. Exposed in URL previews / unfurling.'),
                     ]),
 
             ]);

--- a/app/Models/Division.php
+++ b/app/Models/Division.php
@@ -41,6 +41,7 @@ class Division extends Model
      */
     public array $exposedSettings = [
         'always_visible_in_discord',
+        'meta_description'
     ];
 
     /**


### PR DESCRIPTION
For unfurling and URL previews in discord and other places where the division page is shared