### PR TITLE
Member foreign key normalization

### DIFF
--- a/app/AOD/ClanForumSession.php
+++ b/app/AOD/ClanForumSession.php
@@ -101,7 +101,7 @@ class ClanForumSession
         $user            = new User;
         $user->name      = $username;
         $user->email     = $sessionData->email;
-        $user->member_id = $member->clan_id;
+        $user->member_id = $member->id;
         $user->save();
 
         return $user;

--- a/app/AOD/MemberAwardImage.php
+++ b/app/AOD/MemberAwardImage.php
@@ -127,7 +127,7 @@ class MemberAwardImage
 
     private function fetchAwardsData(Member $member): array
     {
-        $memberAwardCounts = MemberAward::where('member_id', $member->clan_id)
+        $memberAwardCounts = MemberAward::where('member_id', $member->id)
             ->where('approved', true)
             ->selectRaw('award_id, COUNT(*) as count')
             ->groupBy('award_id')

--- a/app/AOD/Traits/GeneratesAwardImages.php
+++ b/app/AOD/Traits/GeneratesAwardImages.php
@@ -49,7 +49,7 @@ trait GeneratesAwardImages
 
     protected function fetchMemberAwardsCollapseTiered(Member $member, array $columns = ['awards.id', 'awards.image', 'awards.prerequisite_award_id']): Collection
     {
-        $memberAwards = MemberAward::where('member_id', $member->clan_id)
+        $memberAwards = MemberAward::where('member_id', $member->id)
             ->join('awards', 'award_member.award_id', '=', 'awards.id')
             ->leftJoin('divisions', 'awards.division_id', '=', 'divisions.id')
             ->where('approved', true)

--- a/app/Filament/Actions/Members/CleanupTenureAwards.php
+++ b/app/Filament/Actions/Members/CleanupTenureAwards.php
@@ -90,14 +90,14 @@ class CleanupTenureAwards
         $joinDate = Carbon::parse($member->join_date);
 
         foreach (self::eligibleMilestones($years, $joinDate) as $milestone => $awardId) {
-            $has = MemberAward::where('member_id', $member->clan_id)
+            $has = MemberAward::where('member_id', $member->id)
                 ->where('award_id', $awardId)
                 ->exists();
 
             if (! $has) {
                 if ($persist) {
                     MemberAward::firstOrCreate(
-                        ['member_id' => $member->clan_id, 'award_id' => $awardId],
+                        ['member_id' => $member->id, 'award_id' => $awardId],
                         ['reason' => "Awarded for reaching the {$milestone}-year milestone.", 'approved' => true],
                     );
                 }
@@ -114,7 +114,7 @@ class CleanupTenureAwards
         $joinDate = Carbon::parse($member->join_date);
         $eligible = self::eligibleMilestones($years, $joinDate);
 
-        $awards = MemberAward::where('member_id', $member->clan_id)
+        $awards = MemberAward::where('member_id', $member->id)
             ->whereIn('award_id', array_values(self::TENURE_AWARD_IDS))
             ->get();
 

--- a/app/Filament/Admin/Resources/LeaveResource.php
+++ b/app/Filament/Admin/Resources/LeaveResource.php
@@ -41,7 +41,7 @@ class LeaveResource extends Resource
             ->components([
                 Select::make('member_id')
                     ->required()
-                    ->exists('members', 'clan_id')
+                    ->exists('members', 'id')
                     ->unique('leaves', 'member_id')
                     ->validationMessages([
                         'unique' => 'Member has an existing leave of absence',

--- a/app/Filament/Admin/Resources/MemberHasManyAwardsResource/RelationManagers/AwardsRelationManager.php
+++ b/app/Filament/Admin/Resources/MemberHasManyAwardsResource/RelationManagers/AwardsRelationManager.php
@@ -38,8 +38,7 @@ class AwardsRelationManager extends RelationManager
                             if (! $award || $award->repeatable) {
                                 return;
                             }
-                            $memberId = $this->ownerRecord->clan_id;
-                            if (MemberAward::where('member_id', $memberId)->where('award_id', $value)->exists()) {
+                            if (MemberAward::where('member_id', $this->ownerRecord->id)->where('award_id', $value)->exists()) {
                                 $fail('This member already has this award.');
                             }
                         },

--- a/app/Filament/Mod/Resources/LeaveResource.php
+++ b/app/Filament/Mod/Resources/LeaveResource.php
@@ -66,7 +66,7 @@ class LeaveResource extends Resource
             ->components([
                 Select::make('member_id')
                     ->required()
-                    ->exists('members', 'clan_id')
+                    ->exists('members', 'id')
                     ->unique('leaves', 'member_id')
                     ->validationMessages([
                         'unique' => 'Member has an existing leave of absence',

--- a/app/Filament/Mod/Resources/LeaveResource/Pages/EditLeave.php
+++ b/app/Filament/Mod/Resources/LeaveResource/Pages/EditLeave.php
@@ -23,7 +23,7 @@ class EditLeave extends EditRecord
                 ->hidden(fn ($action) => // already approved
                     $action->getRecord()->approver_id
                         // leave request for the current user
-                    || $action->getRecord()->member_id === auth()->user()->member->clan_id
+                    || $action->getRecord()->member_id === auth()->user()->member_id
                 )
                 ->requiresConfirmation()
                 ->modalHeading('Approve Leave')

--- a/app/Http/Controllers/AwardController.php
+++ b/app/Http/Controllers/AwardController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Award;
+use App\Models\Member;
 use App\Models\MemberAward;
 use App\Rules\UniqueAwardForMember;
 use Illuminate\Database\Eloquent\Builder;
@@ -224,7 +225,7 @@ class AwardController extends Controller
         $userMember = auth()->user()?->member;
 
         $userAwards = $userMember
-            ? MemberAward::where('member_id', $userMember->clan_id)
+            ? MemberAward::where('member_id', $userMember->id)
                 ->whereIn('award_id', $tierIds)
                 ->where('approved', true)
                 ->get()
@@ -283,7 +284,7 @@ class AwardController extends Controller
         $userMember   = auth()->user()?->member;
         $userHasAward = $userMember
             ? MemberAward::where('award_id', $award->id)
-                ->where('member_id', $userMember->clan_id)
+                ->where('member_id', $userMember->id)
                 ->where('approved', true)
                 ->exists()
             : false;
@@ -320,10 +321,12 @@ class AwardController extends Controller
             ],
         ]);
 
+        $member = Member::whereClanId($validatedData['member_id'])->firstOrFail();
+
         MemberAward::create([
             'requester_id' => auth()->user()->member_id,
             'award_id'     => $award->id,
-            'member_id'    => $validatedData['member_id'],
+            'member_id'    => $member->id,
             'reason'       => $validatedData['reason'],
         ]);
 

--- a/app/Http/Controllers/LeaveController.php
+++ b/app/Http/Controllers/LeaveController.php
@@ -117,7 +117,7 @@ class LeaveController extends Controller
      */
     public function isMemberOfDivision(Division $division, $request)
     {
-        $member = Member::whereClanId($request->member_id)->first();
+        $member = Member::find($request->member_id);
 
         return $member->division instanceof Division
             && $member->division->id === $division->id;

--- a/app/Http/Controllers/MemberController.php
+++ b/app/Http/Controllers/MemberController.php
@@ -77,6 +77,8 @@ class MemberController extends Controller
 
     public function assignPlatoon(Member $member): JsonResponse
     {
+        $this->authorize('recruit', Member::class);
+
         $platoon            = Platoon::find(request()->platoon_id);
         $member->platoon_id = $platoon->id;
         $member->save();
@@ -113,7 +115,7 @@ class MemberController extends Controller
     {
         $this->authorize('remindActivity', $member);
 
-        $alreadyRemindedToday = ActivityReminder::where('member_id', $member->clan_id)
+        $alreadyRemindedToday = ActivityReminder::where('member_id', $member->id)
             ->whereDate('created_at', today())
             ->exists();
 
@@ -125,7 +127,7 @@ class MemberController extends Controller
         }
 
         $reminder = ActivityReminder::create([
-            'member_id'      => $member->clan_id,
+            'member_id'      => $member->id,
             'division_id'    => $member->division_id,
             'reminded_by_id' => auth()->id(),
         ]);
@@ -157,7 +159,7 @@ class MemberController extends Controller
             ], 403);
         }
 
-        $count = ActivityReminder::where('member_id', $member->clan_id)->delete();
+        $count = ActivityReminder::where('member_id', $member->id)->delete();
 
         $member->last_activity_reminder_at = null;
         $member->activity_reminded_by_id   = null;
@@ -187,18 +189,21 @@ class MemberController extends Controller
             return response()->json(['success' => false, 'message' => 'No members selected'], 400);
         }
 
-        $alreadyRemindedToday = ActivityReminder::whereIn('member_id', $memberIds)
+        $members    = Member::whereIn('clan_id', $memberIds)->get()->keyBy('id');
+        $trackerIds = $members->keys()->toArray();
+
+        $alreadyRemindedIds = ActivityReminder::whereIn('member_id', $trackerIds)
             ->whereDate('created_at', today())
             ->pluck('member_id')
             ->toArray();
 
-        $toUpdate = array_diff($memberIds, $alreadyRemindedToday);
+        $toUpdateIds = array_values(array_diff($trackerIds, $alreadyRemindedIds));
 
-        if (empty($toUpdate)) {
+        if (empty($toUpdateIds)) {
             if ($request->has('redirect')) {
                 return redirect($request->input('redirect'))->with('reminder_result', [
                     'count'   => 0,
-                    'skipped' => count($alreadyRemindedToday),
+                    'skipped' => count($alreadyRemindedIds),
                 ]);
             }
 
@@ -212,28 +217,26 @@ class MemberController extends Controller
         $userId    = auth()->id();
         $reminders = [];
 
-        foreach ($toUpdate as $memberId) {
-            $member = Member::where('clan_id', $memberId)->first();
-            if ($member) {
-                $reminders[] = [
-                    'member_id'      => $memberId,
-                    'division_id'    => $member->division_id,
-                    'reminded_by_id' => $userId,
-                    'created_at'     => $now,
-                    'updated_at'     => $now,
-                ];
-            }
+        foreach ($toUpdateIds as $id) {
+            $member      = $members->get($id);
+            $reminders[] = [
+                'member_id'      => $member->id,
+                'division_id'    => $member->division_id,
+                'reminded_by_id' => $userId,
+                'created_at'     => $now,
+                'updated_at'     => $now,
+            ];
         }
 
         ActivityReminder::insert($reminders);
 
-        $count = Member::whereIn('clan_id', $toUpdate)
+        $count = Member::whereIn('id', $toUpdateIds)
             ->update([
                 'last_activity_reminder_at' => $now,
                 'activity_reminded_by_id'   => $userId,
             ]);
 
-        $skippedCount = count($alreadyRemindedToday);
+        $skippedCount = count($alreadyRemindedIds);
 
         if ($request->has('redirect')) {
             return redirect($request->input('redirect'))->with('reminder_result', [
@@ -246,7 +249,7 @@ class MemberController extends Controller
             'success'    => true,
             'count'      => $count,
             'skipped'    => $skippedCount,
-            'updatedIds' => $toUpdate,
+            'updatedIds' => $toUpdateIds,
             'date'       => $now->format('n/j'),
         ]);
     }

--- a/app/Http/Requests/CreateLeave.php
+++ b/app/Http/Requests/CreateLeave.php
@@ -28,7 +28,7 @@ class CreateLeave extends FormRequest
      */
     public function rules()
     {
-        return ['end_date' => 'date|after:today', 'member_id' => ['exists:members,clan_id', 'unique:leaves,member_id']];
+        return ['end_date' => 'date|after:today', 'member_id' => ['exists:members,id', 'unique:leaves,member_id']];
     }
 
     public function messages()
@@ -44,8 +44,7 @@ class CreateLeave extends FormRequest
      */
     public function persist()
     {
-        // search is by clan id, but we want member id (tracker id)
-        $memberRequestingLeave = Member::whereClanId($this->member_id)->firstOrFail();
+        $memberRequestingLeave = Member::findOrFail($this->member_id);
 
         $note = Note::create([
             'body'            => "Leave of absence requested. Reason: {$this->note_body}",

--- a/app/Models/ActivityReminder.php
+++ b/app/Models/ActivityReminder.php
@@ -11,7 +11,7 @@ class ActivityReminder extends Model
 
     public function member(): BelongsTo
     {
-        return $this->belongsTo(Member::class, 'member_id', 'clan_id');
+        return $this->belongsTo(Member::class, 'member_id');
     }
 
     public function division(): BelongsTo

--- a/app/Models/Leave.php
+++ b/app/Models/Leave.php
@@ -37,7 +37,7 @@ class Leave extends Model
      */
     public function member()
     {
-        return $this->belongsTo(Member::class, 'member_id', 'clan_id');
+        return $this->belongsTo(Member::class, 'member_id');
     }
 
     public function division()

--- a/app/Models/Member.php
+++ b/app/Models/Member.php
@@ -64,7 +64,7 @@ class Member extends Model
 
     public function awards()
     {
-        return $this->hasMany(MemberAward::class, 'member_id', 'clan_id')
+        return $this->hasMany(MemberAward::class, 'member_id')
             ->with(['award' => fn ($q) => $q->withCount('recipients')])
             ->where('approved', true);
     }
@@ -86,13 +86,13 @@ class Member extends Model
 
     public function activityReminders()
     {
-        return $this->hasMany(ActivityReminder::class, 'member_id', 'clan_id')
+        return $this->hasMany(ActivityReminder::class, 'member_id')
             ->orderBy('created_at', 'desc');
     }
 
     public function latestActivityReminder()
     {
-        return $this->hasOne(ActivityReminder::class, 'member_id', 'clan_id')
+        return $this->hasOne(ActivityReminder::class, 'member_id')
             ->latestOfMany();
     }
 
@@ -220,7 +220,7 @@ class Member extends Model
      */
     public function leave()
     {
-        return $this->hasOne(Leave::class, 'member_id', 'clan_id');
+        return $this->hasOne(Leave::class, 'member_id');
     }
 
     /**
@@ -236,7 +236,7 @@ class Member extends Model
      */
     public function memberRequest()
     {
-        return $this->hasOne(MemberRequest::class, 'member_id', 'clan_id');
+        return $this->hasOne(MemberRequest::class, 'member_id');
     }
 
     /**
@@ -361,7 +361,7 @@ class Member extends Model
      */
     public function memberRequests()
     {
-        return $this->hasMany(MemberRequest::class, 'requester_id', 'clan_id');
+        return $this->hasMany(MemberRequest::class, 'requester_id');
     }
 
     /**

--- a/app/Models/MemberAward.php
+++ b/app/Models/MemberAward.php
@@ -16,7 +16,7 @@ class MemberAward extends Model
 
     public function member()
     {
-        return $this->belongsTo(Member::class, 'member_id', 'clan_id');
+        return $this->belongsTo(Member::class, 'member_id');
     }
 
     public function requester()

--- a/app/Models/MemberRequest.php
+++ b/app/Models/MemberRequest.php
@@ -21,7 +21,7 @@ class MemberRequest extends Model
      */
     public function member()
     {
-        return $this->belongsTo(Member::class, 'member_id', 'clan_id');
+        return $this->belongsTo(Member::class, 'member_id');
     }
 
     /**
@@ -29,7 +29,7 @@ class MemberRequest extends Model
      */
     public function requester()
     {
-        return $this->belongsTo(Member::class, 'requester_id', 'clan_id');
+        return $this->belongsTo(Member::class, 'requester_id');
     }
 
     /**
@@ -37,7 +37,7 @@ class MemberRequest extends Model
      */
     public function approver()
     {
-        return $this->belongsTo(Member::class, 'approver_id', 'clan_id');
+        return $this->belongsTo(Member::class, 'approver_id');
     }
 
     /**
@@ -106,7 +106,7 @@ class MemberRequest extends Model
     public function approve()
     {
         $this->update([
-            'approver_id' => auth()->user()->member->clan_id, 'approved_at' => now(),
+            'approver_id' => auth()->user()->member_id, 'approved_at' => now(),
         ]);
     }
 
@@ -128,14 +128,14 @@ class MemberRequest extends Model
      */
     public function holder()
     {
-        return $this->belongsTo(Member::class, 'holder_id', 'clan_id');
+        return $this->belongsTo(Member::class, 'holder_id');
     }
 
     public function placeOnHold($notes)
     {
         $this->update([
             'hold_placed_at' => now(),
-            'holder_id'      => auth()->user()->member->clan_id,
+            'holder_id'      => auth()->user()->member_id,
             'notes'          => $notes,
         ]);
     }

--- a/app/Repositories/DivisionRepository.php
+++ b/app/Repositories/DivisionRepository.php
@@ -33,7 +33,7 @@ class DivisionRepository
 
     public function getDivisionAnniversaries(Division $division): Collection
     {
-        $anniversaries = Member::select('name', 'join_date', 'clan_id', 'rank')
+        $anniversaries = Member::select('id', 'name', 'join_date', 'clan_id', 'rank')
             ->selectRaw('TIMESTAMPDIFF(YEAR, join_date, CURRENT_DATE()) + IF(DAY(join_date) > DAY(CURRENT_DATE()), 1, 0) AS years_since_joined')
             ->whereMonth('join_date', now()->month)
             ->whereRaw('TIMESTAMPDIFF(YEAR, join_date, CURRENT_DATE()) + IF(DAY(join_date) > DAY(CURRENT_DATE()), 1, 0) IN (5, 10, 15, 20)')
@@ -52,7 +52,7 @@ class DivisionRepository
             ->pluck('id', 'name');
 
         $earnedAwards = DB::table('award_member')
-            ->whereIn('member_id', $anniversaries->pluck('clan_id'))
+            ->whereIn('member_id', $anniversaries->pluck('id'))
             ->whereIn('award_id', $tenureAwardIds->values())
             ->where('approved', 1)
             ->get(['member_id', 'award_id'])
@@ -60,7 +60,7 @@ class DivisionRepository
 
         return $anniversaries->map(function ($anniversary) use ($tenureAwardIds, $earnedAwards) {
             $awardId      = $tenureAwardIds->get("{$anniversary->years_since_joined} Years of Service");
-            $memberAwards = $earnedAwards->get($anniversary->clan_id);
+            $memberAwards = $earnedAwards->get($anniversary->id);
 
             $anniversary->has_tenure_award = $awardId
                 && $memberAwards

--- a/app/Rules/UniqueAwardForMember.php
+++ b/app/Rules/UniqueAwardForMember.php
@@ -3,6 +3,7 @@
 namespace App\Rules;
 
 use App\Models\Award;
+use App\Models\Member;
 use App\Models\MemberAward;
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
@@ -30,7 +31,9 @@ class UniqueAwardForMember implements ValidationRule
             return;
         }
 
-        if (MemberAward::where('member_id', $value)
+        $member = Member::whereClanId($value)->first();
+
+        if ($member && MemberAward::where('member_id', $member->id)
             ->where('award_id', $this->awardId)
             ->exists()) {
             $fail('This member already has this award.');

--- a/app/Services/RecruitmentService.php
+++ b/app/Services/RecruitmentService.php
@@ -71,13 +71,13 @@ class RecruitmentService
 
     public function createMemberRequest(Member $member, Division $division, int $requesterId): void
     {
-        if (MemberRequest::pending()->whereMemberId($member->clan_id)->exists()) {
+        if (MemberRequest::pending()->whereMemberId($member->id)->exists()) {
             return;
         }
 
         MemberRequest::create([
             'requester_id' => $requesterId,
-            'member_id'    => $member->clan_id,
+            'member_id'    => $member->id,
             'division_id'  => $division->id,
         ]);
     }

--- a/database/factories/LeaveFactory.php
+++ b/database/factories/LeaveFactory.php
@@ -17,7 +17,7 @@ class LeaveFactory extends Factory
         $member = Member::factory()->create();
 
         return [
-            'member_id'    => $member->clan_id,
+            'member_id'    => $member->id,
             'requester_id' => User::factory(),
             'approver_id'  => User::factory(),
             'reason'       => $this->faker->randomElement(array_keys(Leave::$reasons)),

--- a/database/factories/MemberAwardFactory.php
+++ b/database/factories/MemberAwardFactory.php
@@ -14,7 +14,7 @@ class MemberAwardFactory extends Factory
     public function definition(): array
     {
         return [
-            'member_id'    => Member::factory()->create()->clan_id,
+            'member_id'    => Member::factory(),
             'award_id'     => Award::factory(),
             'requester_id' => Member::factory(),
             'approved'     => false,

--- a/database/migrations/2026_05_07_000001_normalize_member_fk_references.php
+++ b/database/migrations/2026_05_07_000001_normalize_member_fk_references.php
@@ -1,0 +1,96 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('activity_reminders', function (Blueprint $table) {
+            $table->dropForeign('activity_reminders_member_id_foreign');
+            $table->unsignedInteger('member_id')->change();
+        });
+
+        DB::statement('
+            UPDATE activity_reminders ar
+            JOIN members m ON m.clan_id = ar.member_id
+            SET ar.member_id = m.id
+            WHERE ar.member_id != m.id
+        ');
+
+        DB::statement('
+            UPDATE activity_reminders ar
+            JOIN members m ON m.clan_id = ar.reminded_by_id
+            SET ar.reminded_by_id = m.id
+            WHERE ar.reminded_by_id != m.id
+        ');
+
+        DB::statement('
+            UPDATE award_member am
+            JOIN members m ON m.clan_id = am.member_id
+            SET am.member_id = m.id
+            WHERE am.member_id != m.id
+        ');
+
+        DB::statement('
+            UPDATE leaves l
+            JOIN members m ON m.clan_id = l.member_id
+            SET l.member_id = m.id
+            WHERE l.member_id != m.id
+        ');
+
+        DB::statement('
+            UPDATE member_requests mr
+            JOIN members m ON m.clan_id = mr.member_id
+            SET mr.member_id = m.id
+            WHERE mr.member_id != m.id
+        ');
+
+        DB::statement('
+            UPDATE member_requests mr
+            JOIN members m ON m.clan_id = mr.requester_id
+            SET mr.requester_id = m.id
+            WHERE mr.requester_id != m.id
+        ');
+
+        DB::statement('
+            UPDATE member_requests mr
+            JOIN members m ON m.clan_id = mr.approver_id
+            SET mr.approver_id = m.id
+            WHERE mr.approver_id != m.id
+        ');
+
+        DB::statement('
+            UPDATE member_requests mr
+            JOIN members m ON m.clan_id = mr.holder_id
+            SET mr.holder_id = m.id
+            WHERE mr.holder_id IS NOT NULL AND mr.holder_id != m.id
+        ');
+
+        DB::statement('
+            UPDATE users u
+            JOIN members m ON m.clan_id = u.member_id
+            SET u.member_id = m.id
+            WHERE u.member_id != m.id
+        ');
+
+        Schema::table('activity_reminders', function (Blueprint $table) {
+            $table->foreign('member_id')->references('id')->on('members')->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('activity_reminders', function (Blueprint $table) {
+            $table->dropForeign(['member_id']);
+            $table->unsignedMediumInteger('member_id')->change();
+        });
+
+        Schema::table('activity_reminders', function (Blueprint $table) {
+            $table->foreign('member_id')->references('clan_id')->on('members')->cascadeOnDelete();
+        });
+    }
+};

--- a/database/schema/mysql-schema.sql
+++ b/database/schema/mysql-schema.sql
@@ -56,7 +56,7 @@ DROP TABLE IF EXISTS `activity_reminders`;
 /*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `activity_reminders` (
   `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
-  `member_id` mediumint(8) unsigned NOT NULL,
+  `member_id` int(10) unsigned NOT NULL,
   `division_id` int(10) unsigned NOT NULL,
   `reminded_by_id` int(10) unsigned NOT NULL,
   `created_at` timestamp NULL DEFAULT NULL,
@@ -66,7 +66,7 @@ CREATE TABLE `activity_reminders` (
   KEY `activity_reminders_division_id_created_at_index` (`division_id`,`created_at`),
   KEY `activity_reminders_reminded_by_id_created_at_index` (`reminded_by_id`,`created_at`),
   CONSTRAINT `activity_reminders_division_id_foreign` FOREIGN KEY (`division_id`) REFERENCES `divisions` (`id`) ON DELETE CASCADE,
-  CONSTRAINT `activity_reminders_member_id_foreign` FOREIGN KEY (`member_id`) REFERENCES `members` (`clan_id`) ON DELETE CASCADE,
+  CONSTRAINT `activity_reminders_member_id_foreign` FOREIGN KEY (`member_id`) REFERENCES `members` (`id`) ON DELETE CASCADE,
   CONSTRAINT `activity_reminders_reminded_by_id_foreign` FOREIGN KEY (`reminded_by_id`) REFERENCES `users` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/tests/Feature/API/ClanApiTest.php
+++ b/tests/Feature/API/ClanApiTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\API;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
 use Laravel\Sanctum\Sanctum;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Traits\CreatesDivisions;
 use Tests\Traits\CreatesMembers;
@@ -15,14 +16,16 @@ class ClanApiTest extends TestCase
     use CreatesMembers;
     use RefreshDatabase;
 
-    public function test_discord_count_requires_authentication()
+    #[Test]
+    public function discord_count_requires_authentication()
     {
         $response = $this->getJson(route('v1.discord_population'));
 
         $response->assertUnauthorized();
     }
 
-    public function test_discord_count_requires_clan_read_ability()
+    #[Test]
+    public function discord_count_requires_clan_read_ability()
     {
         $officer = $this->createOfficer();
 
@@ -33,7 +36,8 @@ class ClanApiTest extends TestCase
         $response->assertForbidden();
     }
 
-    public function test_discord_count_returns_data_with_clan_read_ability()
+    #[Test]
+    public function discord_count_returns_data_with_clan_read_ability()
     {
         $officer = $this->createOfficer();
 
@@ -48,7 +52,8 @@ class ClanApiTest extends TestCase
         $response->assertOk();
     }
 
-    public function test_stream_events_requires_authentication()
+    #[Test]
+    public function stream_events_requires_authentication()
     {
         $response = $this->getJson(route('v1.stream_events'));
 

--- a/tests/Feature/API/DivisionApplicationAuthorizationTest.php
+++ b/tests/Feature/API/DivisionApplicationAuthorizationTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Feature\API;
+
+use App\Models\DivisionApplication;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+use Tests\Traits\CreatesDivisions;
+use Tests\Traits\CreatesMembers;
+
+class DivisionApplicationAuthorizationTest extends TestCase
+{
+    use CreatesDivisions;
+    use CreatesMembers;
+    use RefreshDatabase;
+
+    #[Test]
+    public function officer_cannot_view_application_belonging_to_another_division()
+    {
+        $officer     = $this->createOfficer();
+        $otherDiv    = $this->createActiveDivision();
+        $application = DivisionApplication::factory()->forDivision($otherDiv)->create();
+
+        $this->actingAs($officer)
+            ->getJson(route('division-applications.show', [$officer->member->division->slug, $application->id]))
+            ->assertForbidden();
+    }
+
+    #[Test]
+    public function officer_can_view_application_belonging_to_their_division()
+    {
+        $officer     = $this->createOfficer();
+        $division    = $officer->member->division;
+        $application = DivisionApplication::factory()->forDivision($division)->create();
+
+        $this->actingAs($officer)
+            ->getJson(route('division-applications.show', [$division->slug, $application->id]))
+            ->assertOk();
+    }
+
+    #[Test]
+    public function sr_ldr_cannot_delete_application_from_another_division()
+    {
+        $srLdr       = $this->createSeniorLeader();
+        $otherDiv    = $this->createActiveDivision();
+        $application = DivisionApplication::factory()->forDivision($otherDiv)->create();
+
+        $this->actingAs($srLdr)
+            ->deleteJson(route('division-applications.destroy', [$srLdr->member->division->slug, $application->id]))
+            ->assertForbidden();
+    }
+
+    #[Test]
+    public function officer_cannot_comment_on_application_from_another_division()
+    {
+        $officer     = $this->createOfficer();
+        $otherDiv    = $this->createActiveDivision();
+        $application = DivisionApplication::factory()->forDivision($otherDiv)->create();
+
+        $this->actingAs($officer)
+            ->postJson(route('division-applications.comments.store', [$officer->member->division->slug, $application->id]), [
+                'body' => 'This is a test comment',
+            ])->assertForbidden();
+    }
+}

--- a/tests/Feature/API/TicketApiTest.php
+++ b/tests/Feature/API/TicketApiTest.php
@@ -6,6 +6,7 @@ use App\Models\Ticket;
 use App\Models\TicketType;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Notification;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Traits\CreatesDivisions;
 use Tests\Traits\CreatesMembers;
@@ -22,14 +23,16 @@ class TicketApiTest extends TestCase
         Notification::fake();
     }
 
-    public function test_index_requires_authentication()
+    #[Test]
+    public function index_requires_authentication()
     {
         $response = $this->getJson('/api/tickets');
 
         $response->assertUnauthorized();
     }
 
-    public function test_index_returns_user_tickets()
+    #[Test]
+    public function index_returns_user_tickets()
     {
         $officer    = $this->createOfficer();
         $division   = $officer->member->division;
@@ -56,7 +59,8 @@ class TicketApiTest extends TestCase
         $response->assertJsonMissing(['id' => $otherTicket->id]);
     }
 
-    public function test_types_returns_available_ticket_types()
+    #[Test]
+    public function types_returns_available_ticket_types()
     {
         $officer    = $this->createOfficer();
         $ticketType = TicketType::factory()->create([
@@ -74,7 +78,8 @@ class TicketApiTest extends TestCase
         ]);
     }
 
-    public function test_store_creates_ticket()
+    #[Test]
+    public function store_creates_ticket()
     {
         $officer    = $this->createOfficer();
         $ticketType = TicketType::factory()->create();
@@ -93,7 +98,8 @@ class TicketApiTest extends TestCase
         ]);
     }
 
-    public function test_store_validates_minimum_description_length()
+    #[Test]
+    public function store_validates_minimum_description_length()
     {
         $officer    = $this->createOfficer();
         $ticketType = TicketType::factory()->create();
@@ -108,7 +114,8 @@ class TicketApiTest extends TestCase
         $response->assertJsonValidationErrors('description');
     }
 
-    public function test_show_returns_ticket_for_owner()
+    #[Test]
+    public function show_returns_ticket_for_owner()
     {
         $officer    = $this->createOfficer();
         $division   = $officer->member->division;
@@ -127,7 +134,8 @@ class TicketApiTest extends TestCase
         $response->assertJsonPath('ticket.id', $ticket->id);
     }
 
-    public function test_show_returns_403_for_non_owner()
+    #[Test]
+    public function show_returns_403_for_non_owner()
     {
         $officer    = $this->createOfficer();
         $division   = $officer->member->division;
@@ -147,7 +155,8 @@ class TicketApiTest extends TestCase
         $response->assertForbidden();
     }
 
-    public function test_admin_can_view_any_ticket()
+    #[Test]
+    public function admin_can_view_any_ticket()
     {
         $admin      = $this->createAdmin();
         $division   = $admin->member->division;
@@ -166,7 +175,8 @@ class TicketApiTest extends TestCase
         $response->assertOk();
     }
 
-    public function test_add_comment_to_ticket()
+    #[Test]
+    public function add_comment_to_ticket()
     {
         $officer    = $this->createOfficer();
         $division   = $officer->member->division;
@@ -191,7 +201,8 @@ class TicketApiTest extends TestCase
         ]);
     }
 
-    public function test_cannot_add_comment_to_others_ticket()
+    #[Test]
+    public function cannot_add_comment_to_others_ticket()
     {
         $officer    = $this->createOfficer();
         $division   = $officer->member->division;
@@ -213,7 +224,8 @@ class TicketApiTest extends TestCase
         $response->assertForbidden();
     }
 
-    public function test_deleting_ticket_type_deletes_associated_tickets()
+    #[Test]
+    public function deleting_ticket_type_deletes_associated_tickets()
     {
         $officer    = $this->createOfficer();
         $division   = $officer->member->division;

--- a/tests/Feature/ActivityLoggingTest.php
+++ b/tests/Feature/ActivityLoggingTest.php
@@ -10,6 +10,7 @@ use App\Models\Note;
 use App\Models\Platoon;
 use App\Models\Squad;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Traits\CreatesDivisions;
 use Tests\Traits\CreatesMembers;
@@ -20,7 +21,8 @@ class ActivityLoggingTest extends TestCase
     use CreatesMembers;
     use RefreshDatabase;
 
-    public function test_member_activity_records_correct_type_and_subject()
+    #[Test]
+    public function member_activity_records_correct_type_and_subject()
     {
         $officer  = $this->createOfficer();
         $division = $officer->member->division;
@@ -38,7 +40,8 @@ class ActivityLoggingTest extends TestCase
         $this->assertEquals($division->id, $activity->division_id);
     }
 
-    public function test_activity_records_properties()
+    #[Test]
+    public function activity_records_properties()
     {
         $officer  = $this->createOfficer();
         $division = $officer->member->division;
@@ -57,7 +60,8 @@ class ActivityLoggingTest extends TestCase
         $this->assertEquals($platoon->name, $activity->properties['platoon']);
     }
 
-    public function test_note_creation_logs_activity_on_member()
+    #[Test]
+    public function note_creation_logs_activity_on_member()
     {
         $officer  = $this->createOfficer();
         $division = $officer->member->division;
@@ -80,7 +84,8 @@ class ActivityLoggingTest extends TestCase
         $this->assertEquals('positive', $activity->properties['type']);
     }
 
-    public function test_note_update_logs_activity_on_member()
+    #[Test]
+    public function note_update_logs_activity_on_member()
     {
         $officer  = $this->createOfficer();
         $division = $officer->member->division;
@@ -105,7 +110,8 @@ class ActivityLoggingTest extends TestCase
         $this->assertEquals($member->id, $activity->subject_id);
     }
 
-    public function test_note_deletion_logs_activity_on_member()
+    #[Test]
+    public function note_deletion_logs_activity_on_member()
     {
         $officer  = $this->createOfficer();
         $division = $officer->member->division;
@@ -131,7 +137,8 @@ class ActivityLoggingTest extends TestCase
         $this->assertEquals('negative', $activity->properties['type']);
     }
 
-    public function test_squad_creation_logs_activity()
+    #[Test]
+    public function squad_creation_logs_activity()
     {
         $officer  = $this->createOfficer();
         $division = $officer->member->division;
@@ -151,7 +158,8 @@ class ActivityLoggingTest extends TestCase
         $this->assertEquals(Squad::class, $activity->subject_type);
     }
 
-    public function test_platoon_creation_logs_activity()
+    #[Test]
+    public function platoon_creation_logs_activity()
     {
         $officer  = $this->createOfficer();
         $division = $officer->member->division;
@@ -170,7 +178,8 @@ class ActivityLoggingTest extends TestCase
         $this->assertEquals(Platoon::class, $activity->subject_type);
     }
 
-    public function test_activity_not_recorded_without_authenticated_user()
+    #[Test]
+    public function activity_not_recorded_without_authenticated_user()
     {
         $division = Division::factory()->create();
         $member   = $this->createMember(['division_id' => $division->id]);
@@ -183,7 +192,8 @@ class ActivityLoggingTest extends TestCase
         ]);
     }
 
-    public function test_transfer_activity_includes_destination_properties()
+    #[Test]
+    public function transfer_activity_includes_destination_properties()
     {
         $officer  = $this->createOfficer();
         $division = $officer->member->division;
@@ -204,7 +214,8 @@ class ActivityLoggingTest extends TestCase
         $this->assertEquals('Echo Squad', $activity->properties['squad']);
     }
 
-    public function test_part_time_activity_includes_division_name()
+    #[Test]
+    public function part_time_activity_includes_division_name()
     {
         $officer       = $this->createOfficer();
         $division      = $officer->member->division;
@@ -222,7 +233,8 @@ class ActivityLoggingTest extends TestCase
         $this->assertEquals('Test Division', $activity->properties['division']);
     }
 
-    public function test_activity_type_enum_casts_correctly()
+    #[Test]
+    public function activity_type_enum_casts_correctly()
     {
         $officer = $this->createOfficer();
         $member  = $this->createMember(['division_id' => $officer->member->division_id]);
@@ -237,7 +249,8 @@ class ActivityLoggingTest extends TestCase
         $this->assertEquals('Flagged', $activity->name->label());
     }
 
-    public function test_activity_belongs_to_user()
+    #[Test]
+    public function activity_belongs_to_user()
     {
         $officer = $this->createOfficer();
         $member  = $this->createMember(['division_id' => $officer->member->division_id]);
@@ -251,7 +264,8 @@ class ActivityLoggingTest extends TestCase
         $this->assertEquals($officer->id, $activity->user->id);
     }
 
-    public function test_activity_morph_to_subject()
+    #[Test]
+    public function activity_morph_to_subject()
     {
         $officer = $this->createOfficer();
         $member  = $this->createMember(['division_id' => $officer->member->division_id]);
@@ -266,7 +280,8 @@ class ActivityLoggingTest extends TestCase
         $this->assertEquals($member->id, $activity->subject->id);
     }
 
-    public function test_member_has_activity_relationship()
+    #[Test]
+    public function member_has_activity_relationship()
     {
         $officer = $this->createOfficer();
         $member  = $this->createMember(['division_id' => $officer->member->division_id]);
@@ -280,7 +295,8 @@ class ActivityLoggingTest extends TestCase
         $this->assertTrue($member->activity->pluck('name')->contains(ActivityType::ASSIGNED_PLATOON));
     }
 
-    public function test_empty_properties_stored_as_null()
+    #[Test]
+    public function empty_properties_stored_as_null()
     {
         $officer = $this->createOfficer();
         $member  = $this->createMember(['division_id' => $officer->member->division_id]);

--- a/tests/Feature/AwardImageRoutesTest.php
+++ b/tests/Feature/AwardImageRoutesTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Traits\CreatesMembers;
 
@@ -13,7 +14,8 @@ class AwardImageRoutesTest extends TestCase
     use RefreshDatabase;
 
     #[RunInSeparateProcess]
-    public function test_award_image_routes_return_png_images()
+    #[Test]
+    public function award_image_routes_return_png_images()
     {
         $member = $this->createMember();
 
@@ -35,7 +37,8 @@ class AwardImageRoutesTest extends TestCase
     }
 
     #[RunInSeparateProcess]
-    public function test_member_with_no_awards_returns_default_image()
+    #[Test]
+    public function member_with_no_awards_returns_default_image()
     {
         $member = $this->createMember();
 
@@ -48,7 +51,8 @@ class AwardImageRoutesTest extends TestCase
         $this->assertEquals($expectedImage, $response->getContent());
     }
 
-    public function test_award_image_route_returns_404_for_nonexistent_member()
+    #[Test]
+    public function award_image_route_returns_404_for_nonexistent_member()
     {
         $response = $this->get('/members/999999/my-awards.png');
 

--- a/tests/Feature/Console/DivisionCensusTest.php
+++ b/tests/Feature/Console/DivisionCensusTest.php
@@ -5,13 +5,15 @@ namespace Tests\Feature\Console;
 use App\Models\Census;
 use App\Models\Division;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class DivisionCensusTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_census_command_records_data_for_active_divisions(): void
+    #[Test]
+    public function census_command_records_data_for_active_divisions(): void
     {
         $division = Division::factory()->create();
 
@@ -25,7 +27,8 @@ class DivisionCensusTest extends TestCase
         ]);
     }
 
-    public function test_census_command_skips_when_already_performed_today(): void
+    #[Test]
+    public function census_command_skips_when_already_performed_today(): void
     {
         $division = Division::factory()->create();
 
@@ -41,7 +44,8 @@ class DivisionCensusTest extends TestCase
         $this->assertDatabaseCount('censuses', 1);
     }
 
-    public function test_census_command_runs_with_force_option(): void
+    #[Test]
+    public function census_command_runs_with_force_option(): void
     {
         $division = Division::factory()->create();
 
@@ -57,7 +61,8 @@ class DivisionCensusTest extends TestCase
         $this->assertDatabaseCount('censuses', 2);
     }
 
-    public function test_census_command_runs_when_last_census_was_yesterday(): void
+    #[Test]
+    public function census_command_runs_when_last_census_was_yesterday(): void
     {
         $division = Division::factory()->create();
 
@@ -73,7 +78,8 @@ class DivisionCensusTest extends TestCase
         $this->assertDatabaseCount('censuses', 2);
     }
 
-    public function test_census_handles_no_active_divisions(): void
+    #[Test]
+    public function census_handles_no_active_divisions(): void
     {
         Division::factory()->inactive()->create();
 

--- a/tests/Feature/Console/FetchApplicationFeedsTest.php
+++ b/tests/Feature/Console/FetchApplicationFeedsTest.php
@@ -6,19 +6,22 @@ use App\Models\Division;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class FetchApplicationFeedsTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_command_succeeds_with_no_divisions(): void
+    #[Test]
+    public function command_succeeds_with_no_divisions(): void
     {
         $this->artisan('tracker:fetch-applications')
             ->assertSuccessful();
     }
 
-    public function test_command_skips_divisions_without_rss_feed(): void
+    #[Test]
+    public function command_skips_divisions_without_rss_feed(): void
     {
         Division::factory()->create();
 
@@ -26,7 +29,8 @@ class FetchApplicationFeedsTest extends TestCase
             ->assertSuccessful();
     }
 
-    public function test_command_processes_rss_feed(): void
+    #[Test]
+    public function command_processes_rss_feed(): void
     {
         Http::fake([
             '*' => Http::response($this->sampleRssFeed(), 200),
@@ -41,7 +45,8 @@ class FetchApplicationFeedsTest extends TestCase
         $this->assertTrue(Cache::has('application_item_12345'));
     }
 
-    public function test_command_skips_cached_items(): void
+    #[Test]
+    public function command_skips_cached_items(): void
     {
         Http::fake([
             '*' => Http::response($this->sampleRssFeed(), 200),
@@ -56,7 +61,8 @@ class FetchApplicationFeedsTest extends TestCase
             ->assertSuccessful();
     }
 
-    public function test_fresh_option_clears_cache(): void
+    #[Test]
+    public function fresh_option_clears_cache(): void
     {
         Http::fake([
             '*' => Http::response($this->sampleRssFeed(), 200),
@@ -75,7 +81,8 @@ class FetchApplicationFeedsTest extends TestCase
         $this->assertArrayHasKey('pub_date', $cached);
     }
 
-    public function test_command_skips_excluded_divisions(): void
+    #[Test]
+    public function command_skips_excluded_divisions(): void
     {
         config(['tracker.excluded_divisions' => ['Test Division']]);
 
@@ -90,7 +97,8 @@ class FetchApplicationFeedsTest extends TestCase
         Http::assertNothingSent();
     }
 
-    public function test_command_ignores_invalid_rss_feeds(): void
+    #[Test]
+    public function command_ignores_invalid_rss_feeds(): void
     {
         Http::fake([
             '*' => Http::response('<html><body>Not RSS</body></html>', 200),
@@ -105,7 +113,8 @@ class FetchApplicationFeedsTest extends TestCase
         $this->assertFalse(Cache::has('application_item_12345'));
     }
 
-    public function test_command_handles_empty_rss_feeds(): void
+    #[Test]
+    public function command_handles_empty_rss_feeds(): void
     {
         Http::fake([
             '*' => Http::response($this->emptyRssFeed(), 200),
@@ -118,7 +127,8 @@ class FetchApplicationFeedsTest extends TestCase
             ->assertSuccessful();
     }
 
-    public function test_command_sanitizes_rss_with_trailing_content(): void
+    #[Test]
+    public function command_sanitizes_rss_with_trailing_content(): void
     {
         $rssWithTrailingContent = $this->sampleRssFeed() . "\n\nSome trailing garbage content";
 

--- a/tests/Feature/Console/MakeAODTokenTest.php
+++ b/tests/Feature/Console/MakeAODTokenTest.php
@@ -2,11 +2,13 @@
 
 namespace Tests\Feature\Console;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class MakeAODTokenTest extends TestCase
 {
-    public function test_command_generates_token(): void
+    #[Test]
+    public function command_generates_token(): void
     {
         config(['aod.token' => 'test-secret']);
 
@@ -16,7 +18,8 @@ class MakeAODTokenTest extends TestCase
             ->expectsOutput('Example usage:');
     }
 
-    public function test_token_is_deterministic_within_same_minute(): void
+    #[Test]
+    public function token_is_deterministic_within_same_minute(): void
     {
         config(['aod.token' => 'test-secret']);
 

--- a/tests/Feature/Console/MakeMaintenanceAlertTest.php
+++ b/tests/Feature/Console/MakeMaintenanceAlertTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Console;
 
 use Illuminate\Support\Facades\File;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class MakeMaintenanceAlertTest extends TestCase
@@ -27,7 +28,8 @@ class MakeMaintenanceAlertTest extends TestCase
         parent::tearDown();
     }
 
-    public function test_command_shows_status_when_no_options(): void
+    #[Test]
+    public function command_shows_status_when_no_options(): void
     {
         $this->artisan('tracker:maintenance-alert')
             ->assertSuccessful()
@@ -35,7 +37,8 @@ class MakeMaintenanceAlertTest extends TestCase
             ->expectsOutput('Use --set to create an alert or --clear to remove it.');
     }
 
-    public function test_command_sets_alert_message(): void
+    #[Test]
+    public function command_sets_alert_message(): void
     {
         $this->artisan('tracker:maintenance-alert --set')
             ->expectsQuestion('What would you like the alert set to? (basic HTML allowed)', 'Test maintenance message')
@@ -46,7 +49,8 @@ class MakeMaintenanceAlertTest extends TestCase
         $this->assertEquals('Test maintenance message', File::get($this->alertPath));
     }
 
-    public function test_command_clears_alert(): void
+    #[Test]
+    public function command_clears_alert(): void
     {
         File::put($this->alertPath, 'Existing alert');
 
@@ -57,14 +61,16 @@ class MakeMaintenanceAlertTest extends TestCase
         $this->assertFalse(File::exists($this->alertPath));
     }
 
-    public function test_command_clears_nonexistent_alert(): void
+    #[Test]
+    public function command_clears_nonexistent_alert(): void
     {
         $this->artisan('tracker:maintenance-alert --clear')
             ->assertSuccessful()
             ->expectsOutput('No alert to clear.');
     }
 
-    public function test_command_prompts_before_replacing_existing_alert(): void
+    #[Test]
+    public function command_prompts_before_replacing_existing_alert(): void
     {
         File::put($this->alertPath, 'Existing alert');
 
@@ -77,7 +83,8 @@ class MakeMaintenanceAlertTest extends TestCase
         $this->assertEquals('New message', File::get($this->alertPath));
     }
 
-    public function test_command_does_not_replace_when_declined(): void
+    #[Test]
+    public function command_does_not_replace_when_declined(): void
     {
         File::put($this->alertPath, 'Existing alert');
 

--- a/tests/Feature/Console/MemberSyncTest.php
+++ b/tests/Feature/Console/MemberSyncTest.php
@@ -5,13 +5,15 @@ namespace Tests\Feature\Console;
 use App\Services\MemberSyncService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Mockery;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class MemberSyncTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_command_succeeds_when_sync_service_succeeds(): void
+    #[Test]
+    public function command_succeeds_when_sync_service_succeeds(): void
     {
         $mockService = Mockery::mock(MemberSyncService::class);
         $mockService->shouldReceive('onUpdate')->andReturnSelf();
@@ -32,7 +34,8 @@ class MemberSyncTest extends TestCase
             ->expectsOutputToContain('Sync complete');
     }
 
-    public function test_command_fails_when_no_data_available(): void
+    #[Test]
+    public function command_fails_when_no_data_available(): void
     {
         $mockService = Mockery::mock(MemberSyncService::class);
         $mockService->shouldReceive('onUpdate')->andReturnSelf();
@@ -48,7 +51,8 @@ class MemberSyncTest extends TestCase
             ->expectsOutput('Member sync failed - No data available from forum');
     }
 
-    public function test_command_shows_error_details_on_failure(): void
+    #[Test]
+    public function command_shows_error_details_on_failure(): void
     {
         $mockService = Mockery::mock(MemberSyncService::class);
         $mockService->shouldReceive('onUpdate')->andReturnSelf();

--- a/tests/Feature/Controllers/ActivityReminderTest.php
+++ b/tests/Feature/Controllers/ActivityReminderTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Controllers;
 use App\Enums\Role;
 use App\Models\ActivityReminder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Traits\CreatesDivisions;
 use Tests\Traits\CreatesMembers;
@@ -15,7 +16,8 @@ class ActivityReminderTest extends TestCase
     use CreatesMembers;
     use RefreshDatabase;
 
-    public function test_officer_can_set_activity_reminder()
+    #[Test]
+    public function officer_can_set_activity_reminder()
     {
         $officer  = $this->createOfficer();
         $division = $officer->member->division;
@@ -28,7 +30,7 @@ class ActivityReminderTest extends TestCase
         $response->assertJson(['success' => true]);
 
         $this->assertDatabaseHas('activity_reminders', [
-            'member_id'      => $member->clan_id,
+            'member_id'      => $member->id,
             'division_id'    => $division->id,
             'reminded_by_id' => $officer->id,
         ]);
@@ -38,7 +40,8 @@ class ActivityReminderTest extends TestCase
         $this->assertEquals($officer->id, $member->activity_reminded_by_id);
     }
 
-    public function test_cannot_remind_yourself()
+    #[Test]
+    public function cannot_remind_yourself()
     {
         $officer = $this->createOfficer();
 
@@ -48,14 +51,15 @@ class ActivityReminderTest extends TestCase
         $response->assertForbidden();
     }
 
-    public function test_cannot_remind_same_member_twice_in_one_day()
+    #[Test]
+    public function cannot_remind_same_member_twice_in_one_day()
     {
         $officer  = $this->createOfficer();
         $division = $officer->member->division;
         $member   = $this->createMember(['division_id' => $division->id]);
 
         ActivityReminder::create([
-            'member_id'      => $member->clan_id,
+            'member_id'      => $member->id,
             'division_id'    => $division->id,
             'reminded_by_id' => $officer->id,
         ]);
@@ -67,19 +71,20 @@ class ActivityReminderTest extends TestCase
         $response->assertJson(['message' => 'Already reminded today']);
     }
 
-    public function test_sr_ldr_can_clear_activity_reminders()
+    #[Test]
+    public function sr_ldr_can_clear_activity_reminders()
     {
         $srLdr    = $this->createSeniorLeader();
         $division = $srLdr->member->division;
         $member   = $this->createMember(['division_id' => $division->id]);
 
         ActivityReminder::create([
-            'member_id'      => $member->clan_id,
+            'member_id'      => $member->id,
             'division_id'    => $division->id,
             'reminded_by_id' => $srLdr->id,
         ]);
         ActivityReminder::create([
-            'member_id'      => $member->clan_id,
+            'member_id'      => $member->id,
             'division_id'    => $division->id,
             'reminded_by_id' => $srLdr->id,
             'created_at'     => now()->subDays(7),
@@ -97,7 +102,7 @@ class ActivityReminderTest extends TestCase
         $response->assertJson(['success' => true, 'count' => 2]);
 
         $this->assertDatabaseMissing('activity_reminders', [
-            'member_id' => $member->clan_id,
+            'member_id' => $member->id,
         ]);
 
         $member->refresh();
@@ -105,14 +110,15 @@ class ActivityReminderTest extends TestCase
         $this->assertNull($member->activity_reminded_by_id);
     }
 
-    public function test_officer_cannot_clear_activity_reminders()
+    #[Test]
+    public function officer_cannot_clear_activity_reminders()
     {
         $officer  = $this->createOfficer();
         $division = $officer->member->division;
         $member   = $this->createMember(['division_id' => $division->id]);
 
         ActivityReminder::create([
-            'member_id'      => $member->clan_id,
+            'member_id'      => $member->id,
             'division_id'    => $division->id,
             'reminded_by_id' => $officer->id,
         ]);
@@ -123,12 +129,13 @@ class ActivityReminderTest extends TestCase
         $response->assertForbidden();
     }
 
-    public function test_cannot_clear_own_activity_reminders()
+    #[Test]
+    public function cannot_clear_own_activity_reminders()
     {
         $srLdr = $this->createSeniorLeader();
 
         ActivityReminder::create([
-            'member_id'      => $srLdr->member->clan_id,
+            'member_id'      => $srLdr->member->id,
             'division_id'    => $srLdr->member->division_id,
             'reminded_by_id' => $srLdr->id,
         ]);
@@ -140,7 +147,8 @@ class ActivityReminderTest extends TestCase
         $response->assertJson(['message' => 'Cannot clear your own reminders']);
     }
 
-    public function test_bulk_reminder_creates_reminders_for_multiple_members()
+    #[Test]
+    public function bulk_reminder_creates_reminders_for_multiple_members()
     {
         $officer  = $this->createOfficer();
         $division = $officer->member->division;
@@ -157,12 +165,13 @@ class ActivityReminderTest extends TestCase
 
         $response->assertRedirect();
 
-        $this->assertDatabaseHas('activity_reminders', ['member_id' => $member1->clan_id]);
-        $this->assertDatabaseHas('activity_reminders', ['member_id' => $member2->clan_id]);
-        $this->assertDatabaseHas('activity_reminders', ['member_id' => $member3->clan_id]);
+        $this->assertDatabaseHas('activity_reminders', ['member_id' => $member1->id]);
+        $this->assertDatabaseHas('activity_reminders', ['member_id' => $member2->id]);
+        $this->assertDatabaseHas('activity_reminders', ['member_id' => $member3->id]);
     }
 
-    public function test_bulk_reminder_skips_members_already_reminded_today()
+    #[Test]
+    public function bulk_reminder_skips_members_already_reminded_today()
     {
         $officer  = $this->createOfficer();
         $division = $officer->member->division;
@@ -170,7 +179,7 @@ class ActivityReminderTest extends TestCase
         $member2  = $this->createMember(['division_id' => $division->id]);
 
         ActivityReminder::create([
-            'member_id'      => $member1->clan_id,
+            'member_id'      => $member1->id,
             'division_id'    => $division->id,
             'reminded_by_id' => $officer->id,
         ]);
@@ -187,7 +196,8 @@ class ActivityReminderTest extends TestCase
         $response->assertSessionHas('reminder_result.skipped', 1);
     }
 
-    public function test_unauthenticated_user_cannot_set_reminder()
+    #[Test]
+    public function unauthenticated_user_cannot_set_reminder()
     {
         $division = $this->createActiveDivision();
         $member   = $this->createMember(['division_id' => $division->id]);
@@ -197,7 +207,8 @@ class ActivityReminderTest extends TestCase
         $response->assertUnauthorized();
     }
 
-    public function test_regular_member_cannot_set_activity_reminder()
+    #[Test]
+    public function regular_member_cannot_set_activity_reminder()
     {
         $division     = $this->createActiveDivision();
         $user         = $this->createMemberWithUser(['division_id' => $division->id], ['role' => Role::MEMBER]);

--- a/tests/Feature/Controllers/AssignPlatoonAuthorizationTest.php
+++ b/tests/Feature/Controllers/AssignPlatoonAuthorizationTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Feature\Controllers;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+use Tests\Traits\CreatesDivisions;
+use Tests\Traits\CreatesMembers;
+
+class AssignPlatoonAuthorizationTest extends TestCase
+{
+    use CreatesDivisions;
+    use CreatesMembers;
+    use RefreshDatabase;
+
+    #[Test]
+    public function unauthenticated_user_cannot_assign_platoon()
+    {
+        $division = $this->createActiveDivision();
+        $member   = $this->createMember(['division_id' => $division->id]);
+        $platoon  = $this->createPlatoon($division);
+
+        $this->postJson(route('member.assign-platoon', $member->clan_id), [
+            'platoon_id' => $platoon->id,
+        ])->assertUnauthorized();
+    }
+
+    #[Test]
+    public function regular_member_cannot_assign_platoon()
+    {
+        $division = $this->createActiveDivision();
+        $user     = $this->createMemberWithUser(['division_id' => $division->id]);
+        $target   = $this->createMember(['division_id' => $division->id]);
+        $platoon  = $this->createPlatoon($division);
+
+        $this->actingAs($user)
+            ->postJson(route('member.assign-platoon', $target->clan_id), [
+                'platoon_id' => $platoon->id,
+            ])->assertForbidden();
+    }
+
+    #[Test]
+    public function officer_can_assign_platoon()
+    {
+        $officer = $this->createOfficer();
+        $target  = $this->createMember(['division_id' => $officer->member->division_id]);
+        $platoon = $this->createPlatoon($officer->member->division);
+
+        $this->actingAs($officer)
+            ->postJson(route('member.assign-platoon', $target->clan_id), [
+                'platoon_id' => $platoon->id,
+            ])->assertOk();
+
+        $this->assertEquals($platoon->id, $target->fresh()->platoon_id);
+    }
+}

--- a/tests/Feature/Controllers/AssignSquadAuthorizationTest.php
+++ b/tests/Feature/Controllers/AssignSquadAuthorizationTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Feature\Controllers;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+use Tests\Traits\CreatesDivisions;
+use Tests\Traits\CreatesMembers;
+
+class AssignSquadAuthorizationTest extends TestCase
+{
+    use CreatesDivisions;
+    use CreatesMembers;
+    use RefreshDatabase;
+
+    #[Test]
+    public function unauthenticated_user_cannot_assign_squad()
+    {
+        $division = $this->createActiveDivision();
+        $member   = $this->createMember(['division_id' => $division->id]);
+        $squad    = $this->createSquad($this->createPlatoon($division));
+
+        $this->postJson('/members/assign-squad', [
+            'member_id' => $member->id,
+            'squad_id'  => $squad->id,
+        ])->assertUnauthorized();
+    }
+
+    #[Test]
+    public function regular_member_cannot_assign_squad()
+    {
+        $division = $this->createActiveDivision();
+        $user     = $this->createMemberWithUser(['division_id' => $division->id]);
+        $target   = $this->createMember(['division_id' => $division->id]);
+        $squad    = $this->createSquad($this->createPlatoon($division));
+
+        $this->actingAs($user)
+            ->postJson('/members/assign-squad', [
+                'member_id' => $target->id,
+                'squad_id'  => $squad->id,
+            ])->assertForbidden();
+    }
+
+    #[Test]
+    public function officer_can_assign_squad()
+    {
+        $officer = $this->createOfficer();
+        $target  = $this->createMember(['division_id' => $officer->member->division_id]);
+        $platoon = $this->createPlatoon($officer->member->division);
+        $squad   = $this->createSquad($platoon);
+
+        $this->actingAs($officer)
+            ->postJson('/members/assign-squad', [
+                'member_id' => $target->id,
+                'squad_id'  => $squad->id,
+            ])->assertOk();
+
+        $target->refresh();
+        $this->assertEquals($squad->id, $target->squad_id);
+        $this->assertEquals($platoon->id, $target->platoon_id);
+    }
+}

--- a/tests/Feature/Controllers/BotCommandControllerTest.php
+++ b/tests/Feature/Controllers/BotCommandControllerTest.php
@@ -7,6 +7,7 @@ use App\Models\Division;
 use App\Models\Member;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Testing\TestResponse;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class BotCommandControllerTest extends TestCase
@@ -28,13 +29,15 @@ class BotCommandControllerTest extends TestCase
         ));
     }
 
-    public function test_bot_command_requires_valid_token()
+    #[Test]
+    public function bot_command_requires_valid_token()
     {
         $this->getJson(route('bot.commands', ['command' => 'reports']) . '?token=invalid&value=sgt-training')
             ->assertStatus(401);
     }
 
-    public function test_unknown_command_returns_unrecognized_message()
+    #[Test]
+    public function unknown_command_returns_unrecognized_message()
     {
         $response = $this->botGet('nonexistent-command');
 
@@ -42,13 +45,15 @@ class BotCommandControllerTest extends TestCase
             ->assertJson(['message' => 'Unrecognized command. Sorry!']);
     }
 
-    public function test_reports_command_requires_value()
+    #[Test]
+    public function reports_command_requires_value()
     {
         $this->botGet('reports')
             ->assertStatus(422);
     }
 
-    public function test_reports_command_returns_not_found_for_unknown_report()
+    #[Test]
+    public function reports_command_returns_not_found_for_unknown_report()
     {
         $response = $this->botGet('reports', ['value' => 'nonexistent-report']);
 
@@ -56,7 +61,8 @@ class BotCommandControllerTest extends TestCase
             ->assertJson(['message' => "Report 'nonexistent-report' not found."]);
     }
 
-    public function test_sgt_training_report_returns_message_with_table()
+    #[Test]
+    public function sgt_training_report_returns_message_with_table()
     {
         $division = Division::factory()->create(['active' => true]);
 
@@ -84,7 +90,8 @@ class BotCommandControllerTest extends TestCase
         $this->assertStringContainsString('3', $message);
     }
 
-    public function test_sgt_training_report_returns_message_when_no_ssgts()
+    #[Test]
+    public function sgt_training_report_returns_message_when_no_ssgts()
     {
         $response = $this->botGet('reports', ['value' => 'sgt-training']);
 

--- a/tests/Feature/Controllers/BulkTagControllerTest.php
+++ b/tests/Feature/Controllers/BulkTagControllerTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Controllers;
 
 use App\Models\DivisionTag;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Traits\CreatesDivisions;
 use Tests\Traits\CreatesMembers;
@@ -14,7 +15,8 @@ class BulkTagControllerTest extends TestCase
     use CreatesMembers;
     use RefreshDatabase;
 
-    public function test_bulk_store_assigns_tags_to_multiple_members()
+    #[Test]
+    public function bulk_store_assigns_tags_to_multiple_members()
     {
         $srLdr    = $this->createSeniorLeader();
         $division = $srLdr->member->division;
@@ -35,7 +37,8 @@ class BulkTagControllerTest extends TestCase
         $this->assertTrue($member2->fresh()->tags->contains($tag));
     }
 
-    public function test_bulk_store_removes_tags_from_multiple_members()
+    #[Test]
+    public function bulk_store_removes_tags_from_multiple_members()
     {
         $srLdr    = $this->createSeniorLeader();
         $division = $srLdr->member->division;
@@ -58,7 +61,8 @@ class BulkTagControllerTest extends TestCase
         $this->assertFalse($member2->fresh()->tags->contains($tag));
     }
 
-    public function test_bulk_store_requires_authentication()
+    #[Test]
+    public function bulk_store_requires_authentication()
     {
         $division = $this->createActiveDivision();
 

--- a/tests/Feature/Controllers/DiscordAuthTest.php
+++ b/tests/Feature/Controllers/DiscordAuthTest.php
@@ -21,6 +21,7 @@ use Illuminate\Support\Facades\Notification;
 use Laravel\Socialite\Facades\Socialite;
 use Laravel\Socialite\Two\User as SocialiteUser;
 use Mockery;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class DiscordAuthTest extends TestCase
@@ -53,7 +54,8 @@ class DiscordAuthTest extends TestCase
             ->andReturn($provider);
     }
 
-    public function test_discord_redirect_redirects_to_discord(): void
+    #[Test]
+    public function discord_redirect_redirects_to_discord(): void
     {
         $provider = Mockery::mock('Laravel\Socialite\Contracts\Provider');
         $provider->shouldReceive('redirect')
@@ -68,7 +70,8 @@ class DiscordAuthTest extends TestCase
         $response->assertRedirect();
     }
 
-    public function test_discord_callback_creates_pending_user_for_unknown_discord_id(): void
+    #[Test]
+    public function discord_callback_creates_pending_user_for_unknown_discord_id(): void
     {
         $this->mockDiscordUser([
             'id'       => '999888777',
@@ -88,7 +91,8 @@ class DiscordAuthTest extends TestCase
         $response->assertRedirect(route('auth.discord.pending'));
     }
 
-    public function test_discord_callback_finds_existing_member_by_discord_id(): void
+    #[Test]
+    public function discord_callback_finds_existing_member_by_discord_id(): void
     {
         $member = Member::factory()->create(['discord_id' => '111222333']);
 
@@ -108,7 +112,8 @@ class DiscordAuthTest extends TestCase
         $response->assertRedirect('/');
     }
 
-    public function test_discord_callback_uses_existing_user_with_discord_id(): void
+    #[Test]
+    public function discord_callback_uses_existing_user_with_discord_id(): void
     {
         $member = Member::factory()->create(['discord_id' => '777888999']);
         $user   = User::factory()->create([
@@ -128,7 +133,8 @@ class DiscordAuthTest extends TestCase
         $response->assertRedirect('/');
     }
 
-    public function test_discord_callback_redirects_pending_user_to_pending_page(): void
+    #[Test]
+    public function discord_callback_redirects_pending_user_to_pending_page(): void
     {
         $user = User::factory()->pending()->create([
             'discord_id'       => '555666777',
@@ -146,7 +152,8 @@ class DiscordAuthTest extends TestCase
         $response->assertRedirect(route('auth.discord.pending'));
     }
 
-    public function test_discord_callback_rejects_new_user_without_email(): void
+    #[Test]
+    public function discord_callback_rejects_new_user_without_email(): void
     {
         $this->mockDiscordUser([
             'id'       => '123123123',
@@ -162,7 +169,8 @@ class DiscordAuthTest extends TestCase
         $this->assertDatabaseMissing('users', ['discord_id' => '123123123']);
     }
 
-    public function test_discord_callback_rejects_duplicate_email(): void
+    #[Test]
+    public function discord_callback_rejects_duplicate_email(): void
     {
         User::factory()->create(['email' => 'taken@example.com']);
 
@@ -180,7 +188,8 @@ class DiscordAuthTest extends TestCase
         $this->assertDatabaseMissing('users', ['discord_id' => '321321321']);
     }
 
-    public function test_discord_callback_sanitizes_username(): void
+    #[Test]
+    public function discord_callback_sanitizes_username(): void
     {
         $this->mockDiscordUser([
             'id'       => '444555666',
@@ -196,7 +205,8 @@ class DiscordAuthTest extends TestCase
         $response->assertRedirect(route('auth.discord.pending'));
     }
 
-    public function test_discord_callback_uses_name_when_nickname_null(): void
+    #[Test]
+    public function discord_callback_uses_name_when_nickname_null(): void
     {
         $this->mockDiscordUser([
             'id'       => '666777888',
@@ -213,7 +223,8 @@ class DiscordAuthTest extends TestCase
         $response->assertRedirect(route('auth.discord.pending'));
     }
 
-    public function test_discord_callback_links_discord_to_existing_member_user(): void
+    #[Test]
+    public function discord_callback_links_discord_to_existing_member_user(): void
     {
         $member = Member::factory()->create(['discord_id' => '888999000']);
         $user   = User::factory()->create([
@@ -234,14 +245,16 @@ class DiscordAuthTest extends TestCase
         $this->assertEquals('LinkedUser', $user->discord_username);
     }
 
-    public function test_pending_page_requires_authentication(): void
+    #[Test]
+    public function pending_page_requires_authentication(): void
     {
         $response = $this->get(route('auth.discord.pending'));
 
         $response->assertRedirect(route('login'));
     }
 
-    public function test_pending_page_redirects_completed_users_to_home(): void
+    #[Test]
+    public function pending_page_redirects_completed_users_to_home(): void
     {
         $member = Member::factory()->create();
         $user   = User::factory()->create([
@@ -254,7 +267,8 @@ class DiscordAuthTest extends TestCase
         $response->assertRedirect('/');
     }
 
-    public function test_pending_page_displays_for_pending_users(): void
+    #[Test]
+    public function pending_page_displays_for_pending_users(): void
     {
         $user = User::factory()->pending()->create([
             'discord_id'       => '123456789',
@@ -268,7 +282,8 @@ class DiscordAuthTest extends TestCase
         $response->assertSee('ClanAOD Registration');
     }
 
-    public function test_user_is_pending_registration_returns_true_for_discord_only(): void
+    #[Test]
+    public function user_is_pending_registration_returns_true_for_discord_only(): void
     {
         $user = User::factory()->pending()->create([
             'discord_id' => '123456789',
@@ -277,7 +292,8 @@ class DiscordAuthTest extends TestCase
         $this->assertTrue($user->isPendingRegistration());
     }
 
-    public function test_user_is_pending_registration_returns_false_for_linked_member(): void
+    #[Test]
+    public function user_is_pending_registration_returns_false_for_linked_member(): void
     {
         $member = Member::factory()->create();
         $user   = User::factory()->create([
@@ -288,7 +304,8 @@ class DiscordAuthTest extends TestCase
         $this->assertFalse($user->isPendingRegistration());
     }
 
-    public function test_user_has_member_returns_correct_value(): void
+    #[Test]
+    public function user_has_member_returns_correct_value(): void
     {
         $member            = Member::factory()->create();
         $userWithMember    = User::factory()->create(['member_id' => $member->id]);
@@ -298,7 +315,8 @@ class DiscordAuthTest extends TestCase
         $this->assertFalse($userWithoutMember->hasMember());
     }
 
-    public function test_pending_user_is_redirected_to_pending_page_on_other_routes(): void
+    #[Test]
+    public function pending_user_is_redirected_to_pending_page_on_other_routes(): void
     {
         $user = User::factory()->pending()->create();
 
@@ -307,7 +325,8 @@ class DiscordAuthTest extends TestCase
         $response->assertRedirect(route('auth.discord.pending'));
     }
 
-    public function test_pending_user_can_logout(): void
+    #[Test]
+    public function pending_user_can_logout(): void
     {
         $user = User::factory()->pending()->create();
 
@@ -317,7 +336,8 @@ class DiscordAuthTest extends TestCase
         $this->assertGuest();
     }
 
-    public function test_pending_discord_scope_returns_only_pending_users(): void
+    #[Test]
+    public function pending_discord_scope_returns_only_pending_users(): void
     {
         $member = Member::factory()->create();
         User::factory()->create(['member_id' => $member->id, 'discord_id' => '111']);
@@ -332,7 +352,8 @@ class DiscordAuthTest extends TestCase
         $this->assertTrue($pendingUsers->contains($pendingUser2));
     }
 
-    public function test_discord_callback_syncs_forum_roles_for_new_user(): void
+    #[Test]
+    public function discord_callback_syncs_forum_roles_for_new_user(): void
     {
         $member = Member::factory()->create([
             'discord_id' => '123456789',
@@ -361,7 +382,8 @@ class DiscordAuthTest extends TestCase
         $this->assertEquals(Role::SENIOR_LEADER, $user->role);
     }
 
-    public function test_discord_callback_syncs_forum_roles_for_existing_user(): void
+    #[Test]
+    public function discord_callback_syncs_forum_roles_for_existing_user(): void
     {
         $member = Member::factory()->create([
             'discord_id' => '987654321',
@@ -394,7 +416,8 @@ class DiscordAuthTest extends TestCase
         $this->assertEquals(Role::ADMIN, $user->role);
     }
 
-    public function test_discord_registration_queues_notification_when_division_selected(): void
+    #[Test]
+    public function discord_registration_queues_notification_when_division_selected(): void
     {
         Notification::fake();
 
@@ -430,7 +453,8 @@ class DiscordAuthTest extends TestCase
         Notification::assertSentTo($division, NotifyDivisionPendingDiscordRegistration::class);
     }
 
-    public function test_discord_registration_does_not_queue_notification_without_division(): void
+    #[Test]
+    public function discord_registration_does_not_queue_notification_without_division(): void
     {
         Notification::fake();
 
@@ -450,7 +474,8 @@ class DiscordAuthTest extends TestCase
         Notification::assertNothingSent();
     }
 
-    public function test_discord_registration_rejects_date_of_birth_under_13(): void
+    #[Test]
+    public function discord_registration_rejects_date_of_birth_under_13(): void
     {
         $user = User::factory()->pending()->create([
             'discord_id'     => '123456789',
@@ -475,7 +500,8 @@ class DiscordAuthTest extends TestCase
             ->assertSessionHasErrors('date_of_birth');
     }
 
-    public function test_discord_registration_rejects_unrealistically_old_date_of_birth(): void
+    #[Test]
+    public function discord_registration_rejects_unrealistically_old_date_of_birth(): void
     {
         $user = User::factory()->pending()->create([
             'discord_id'     => '123456789',
@@ -500,7 +526,8 @@ class DiscordAuthTest extends TestCase
             ->assertSessionHasErrors('date_of_birth');
     }
 
-    public function test_discord_registration_rejects_future_date_of_birth(): void
+    #[Test]
+    public function discord_registration_rejects_future_date_of_birth(): void
     {
         $user = User::factory()->pending()->create([
             'discord_id'     => '123456789',
@@ -525,7 +552,8 @@ class DiscordAuthTest extends TestCase
             ->assertSessionHasErrors('date_of_birth');
     }
 
-    public function test_discord_registration_accepts_valid_date_of_birth(): void
+    #[Test]
+    public function discord_registration_accepts_valid_date_of_birth(): void
     {
         Notification::fake();
 
@@ -559,7 +587,8 @@ class DiscordAuthTest extends TestCase
             ->assertRedirect();
     }
 
-    public function test_discord_registration_rejects_invalid_date_format(): void
+    #[Test]
+    public function discord_registration_rejects_invalid_date_format(): void
     {
         $user = User::factory()->pending()->create([
             'discord_id'     => '123456789',
@@ -584,7 +613,8 @@ class DiscordAuthTest extends TestCase
             ->assertSessionHasErrors('date_of_birth');
     }
 
-    public function test_discord_registration_rejects_username_already_taken_on_forums(): void
+    #[Test]
+    public function discord_registration_rejects_username_already_taken_on_forums(): void
     {
         $division = Division::factory()->create(['active' => true]);
         Member::factory()->create([
@@ -616,7 +646,8 @@ class DiscordAuthTest extends TestCase
             ->assertSessionHasErrors('username');
     }
 
-    public function test_discord_registration_accepts_username_not_taken_on_forums(): void
+    #[Test]
+    public function discord_registration_accepts_username_not_taken_on_forums(): void
     {
         Notification::fake();
 
@@ -652,7 +683,8 @@ class DiscordAuthTest extends TestCase
             ->assertSessionHasNoErrors();
     }
 
-    public function test_discord_registration_does_not_send_duplicate_notification_on_resubmit(): void
+    #[Test]
+    public function discord_registration_does_not_send_duplicate_notification_on_resubmit(): void
     {
         Notification::fake();
 
@@ -685,7 +717,8 @@ class DiscordAuthTest extends TestCase
         Notification::assertNothingSent();
     }
 
-    public function test_discord_registration_does_not_dispatch_duplicate_forum_account_job_on_resubmit(): void
+    #[Test]
+    public function discord_registration_does_not_dispatch_duplicate_forum_account_job_on_resubmit(): void
     {
         Bus::fake();
 
@@ -717,7 +750,8 @@ class DiscordAuthTest extends TestCase
         Bus::assertNotDispatched(CreateForumAccount::class);
     }
 
-    public function test_discord_callback_handles_oauth_failure_gracefully(): void
+    #[Test]
+    public function discord_callback_handles_oauth_failure_gracefully(): void
     {
         $provider = Mockery::mock('Laravel\Socialite\Contracts\Provider');
         $provider->shouldReceive('user')

--- a/tests/Feature/Controllers/DivisionControllerTest.php
+++ b/tests/Feature/Controllers/DivisionControllerTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Controllers;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Traits\CreatesDivisions;
 use Tests\Traits\CreatesMembers;
@@ -13,7 +14,8 @@ class DivisionControllerTest extends TestCase
     use CreatesMembers;
     use RefreshDatabase;
 
-    public function test_show_displays_division_page()
+    #[Test]
+    public function show_displays_division_page()
     {
         $officer  = $this->createOfficer();
         $division = $officer->member->division;
@@ -24,7 +26,8 @@ class DivisionControllerTest extends TestCase
         $response->assertOk();
     }
 
-    public function test_show_requires_authentication()
+    #[Test]
+    public function show_requires_authentication()
     {
         $division = $this->createActiveDivision();
 

--- a/tests/Feature/Controllers/ForumLoginTest.php
+++ b/tests/Feature/Controllers/ForumLoginTest.php
@@ -6,13 +6,15 @@ use App\Models\Member;
 use App\Models\User;
 use App\Services\AODForumService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class ForumLoginTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_login_uses_clan_id_not_name_to_find_member(): void
+    #[Test]
+    public function login_uses_clan_id_not_name_to_find_member(): void
     {
         $member1 = Member::factory()->create([
             'clan_id' => 11111,

--- a/tests/Feature/Controllers/ImpersonationTest.php
+++ b/tests/Feature/Controllers/ImpersonationTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Controllers;
 
 use App\Enums\Role;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Traits\CreatesDivisions;
 use Tests\Traits\CreatesMembers;
@@ -14,7 +15,8 @@ class ImpersonationTest extends TestCase
     use CreatesMembers;
     use RefreshDatabase;
 
-    public function test_admin_can_impersonate_regular_user()
+    #[Test]
+    public function admin_can_impersonate_regular_user()
     {
         $admin   = $this->createAdmin();
         $officer = $this->createOfficer();
@@ -27,7 +29,8 @@ class ImpersonationTest extends TestCase
         $this->assertTrue(session('impersonating'));
     }
 
-    public function test_admin_cannot_impersonate_developer()
+    #[Test]
+    public function admin_cannot_impersonate_developer()
     {
         $admin     = $this->createAdmin([], ['developer' => false]);
         $developer = $this->createAdmin([], ['developer' => true]);
@@ -39,7 +42,8 @@ class ImpersonationTest extends TestCase
         $this->assertAuthenticatedAs($admin);
     }
 
-    public function test_admin_cannot_impersonate_themselves()
+    #[Test]
+    public function admin_cannot_impersonate_themselves()
     {
         $admin = $this->createAdmin();
 
@@ -49,7 +53,8 @@ class ImpersonationTest extends TestCase
         $response->assertForbidden();
     }
 
-    public function test_officer_cannot_impersonate()
+    #[Test]
+    public function officer_cannot_impersonate()
     {
         $officer = $this->createOfficer();
         $member  = $this->createMemberWithUser();
@@ -60,7 +65,8 @@ class ImpersonationTest extends TestCase
         $response->assertForbidden();
     }
 
-    public function test_cannot_impersonate_while_already_impersonating()
+    #[Test]
+    public function cannot_impersonate_while_already_impersonating()
     {
         $admin    = $this->createAdmin();
         $officer1 = $this->createOfficer();
@@ -72,7 +78,8 @@ class ImpersonationTest extends TestCase
             ->assertForbidden();
     }
 
-    public function test_developer_can_impersonate_in_local_environment()
+    #[Test]
+    public function developer_can_impersonate_in_local_environment()
     {
         $this->app->detectEnvironment(fn () => 'local');
 
@@ -86,7 +93,8 @@ class ImpersonationTest extends TestCase
         $this->assertAuthenticatedAs($otherDeveloper);
     }
 
-    public function test_developer_can_impersonate_in_testing_environment()
+    #[Test]
+    public function developer_can_impersonate_in_testing_environment()
     {
         $this->app->detectEnvironment(fn () => 'testing');
 
@@ -100,7 +108,8 @@ class ImpersonationTest extends TestCase
         $this->assertAuthenticatedAs($officer);
     }
 
-    public function test_developer_cannot_impersonate_in_production()
+    #[Test]
+    public function developer_cannot_impersonate_in_production()
     {
         $this->app->detectEnvironment(fn () => 'production');
 
@@ -113,7 +122,8 @@ class ImpersonationTest extends TestCase
         $response->assertForbidden();
     }
 
-    public function test_end_impersonation_returns_to_original_user()
+    #[Test]
+    public function end_impersonation_returns_to_original_user()
     {
         $admin   = $this->createAdmin();
         $officer = $this->createOfficer();

--- a/tests/Feature/Controllers/LeaveControllerTest.php
+++ b/tests/Feature/Controllers/LeaveControllerTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Controllers;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Traits\CreatesDivisions;
 use Tests\Traits\CreatesMembers;
@@ -13,7 +14,8 @@ class LeaveControllerTest extends TestCase
     use CreatesMembers;
     use RefreshDatabase;
 
-    public function test_index_requires_authentication()
+    #[Test]
+    public function index_requires_authentication()
     {
         $division = $this->createActiveDivision();
 
@@ -22,7 +24,8 @@ class LeaveControllerTest extends TestCase
         $response->assertRedirect('/login');
     }
 
-    public function test_store_validates_member_belongs_to_division()
+    #[Test]
+    public function store_validates_member_belongs_to_division()
     {
         $srLdr         = $this->createSeniorLeader();
         $division      = $srLdr->member->division;

--- a/tests/Feature/Controllers/LeaveControllerTest.php
+++ b/tests/Feature/Controllers/LeaveControllerTest.php
@@ -31,7 +31,7 @@ class LeaveControllerTest extends TestCase
 
         $response = $this->actingAs($srLdr)
             ->post(route('leave.store', $division->slug), [
-                'member_id' => $member->clan_id,
+                'member_id' => $member->id,
                 'end_date'  => now()->addMonth()->format('Y-m-d'),
                 'reason'    => 'Test reason',
             ]);

--- a/tests/Feature/Controllers/LogViewerAccessTest.php
+++ b/tests/Feature/Controllers/LogViewerAccessTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Controllers;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Traits\CreatesDivisions;
 use Tests\Traits\CreatesMembers;
@@ -13,7 +14,8 @@ class LogViewerAccessTest extends TestCase
     use CreatesMembers;
     use RefreshDatabase;
 
-    public function test_developer_can_access_log_viewer()
+    #[Test]
+    public function developer_can_access_log_viewer()
     {
         $developer = $this->createMemberWithUser([], ['developer' => true]);
 
@@ -23,7 +25,8 @@ class LogViewerAccessTest extends TestCase
         $response->assertOk();
     }
 
-    public function test_admin_with_developer_flag_can_access_log_viewer()
+    #[Test]
+    public function admin_with_developer_flag_can_access_log_viewer()
     {
         $admin = $this->createAdmin([], ['developer' => true]);
 
@@ -33,7 +36,8 @@ class LogViewerAccessTest extends TestCase
         $response->assertOk();
     }
 
-    public function test_admin_without_developer_flag_cannot_access_log_viewer()
+    #[Test]
+    public function admin_without_developer_flag_cannot_access_log_viewer()
     {
         $admin = $this->createAdmin([], ['developer' => false]);
 
@@ -43,7 +47,8 @@ class LogViewerAccessTest extends TestCase
         $response->assertForbidden();
     }
 
-    public function test_senior_leader_cannot_access_log_viewer()
+    #[Test]
+    public function senior_leader_cannot_access_log_viewer()
     {
         $seniorLeader = $this->createSeniorLeader();
 
@@ -53,7 +58,8 @@ class LogViewerAccessTest extends TestCase
         $response->assertForbidden();
     }
 
-    public function test_officer_cannot_access_log_viewer()
+    #[Test]
+    public function officer_cannot_access_log_viewer()
     {
         $officer = $this->createOfficer();
 
@@ -63,7 +69,8 @@ class LogViewerAccessTest extends TestCase
         $response->assertForbidden();
     }
 
-    public function test_regular_member_cannot_access_log_viewer()
+    #[Test]
+    public function regular_member_cannot_access_log_viewer()
     {
         $member = $this->createMemberWithUser();
 
@@ -73,7 +80,8 @@ class LogViewerAccessTest extends TestCase
         $response->assertForbidden();
     }
 
-    public function test_unauthenticated_user_cannot_access_log_viewer()
+    #[Test]
+    public function unauthenticated_user_cannot_access_log_viewer()
     {
         $response = $this->get('/log-viewer');
 

--- a/tests/Feature/Controllers/MemberDivisionDisplayTest.php
+++ b/tests/Feature/Controllers/MemberDivisionDisplayTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Controllers;
 
 use App\Models\Transfer;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Traits\CreatesDivisions;
 use Tests\Traits\CreatesMembers;
@@ -14,7 +15,8 @@ class MemberDivisionDisplayTest extends TestCase
     use CreatesMembers;
     use RefreshDatabase;
 
-    public function test_primary_division_card_is_shown()
+    #[Test]
+    public function primary_division_card_is_shown()
     {
         $user   = $this->createMemberWithUser();
         $member = $user->member;
@@ -27,7 +29,8 @@ class MemberDivisionDisplayTest extends TestCase
             ->assertSee('Primary');
     }
 
-    public function test_part_time_divisions_are_shown()
+    #[Test]
+    public function part_time_divisions_are_shown()
     {
         $user     = $this->createMemberWithUser();
         $member   = $user->member;
@@ -42,7 +45,8 @@ class MemberDivisionDisplayTest extends TestCase
             ->assertSee('Part-Time');
     }
 
-    public function test_part_time_badge_is_absent_when_none_assigned()
+    #[Test]
+    public function part_time_badge_is_absent_when_none_assigned()
     {
         $user = $this->createMemberWithUser();
 
@@ -52,7 +56,8 @@ class MemberDivisionDisplayTest extends TestCase
             ->assertDontSee('division-card-badge--secondary', false);
     }
 
-    public function test_past_divisions_are_shown_from_transfer_history()
+    #[Test]
+    public function past_divisions_are_shown_from_transfer_history()
     {
         $user    = $this->createMemberWithUser();
         $member  = $user->member;
@@ -76,7 +81,8 @@ class MemberDivisionDisplayTest extends TestCase
             ->assertSee('division-chip', false);
     }
 
-    public function test_past_section_is_absent_with_no_transfer_history()
+    #[Test]
+    public function past_section_is_absent_with_no_transfer_history()
     {
         $user = $this->createMemberWithUser();
 
@@ -86,7 +92,8 @@ class MemberDivisionDisplayTest extends TestCase
             ->assertDontSee('division-chip', false);
     }
 
-    public function test_repeated_past_division_visits_are_grouped_with_count_badge()
+    #[Test]
+    public function repeated_past_division_visits_are_grouped_with_count_badge()
     {
         $user         = $this->createMemberWithUser();
         $member       = $user->member;
@@ -105,7 +112,8 @@ class MemberDivisionDisplayTest extends TestCase
         $response->assertSee($returningDiv->name);
     }
 
-    public function test_current_division_is_excluded_from_past_section()
+    #[Test]
+    public function current_division_is_excluded_from_past_section()
     {
         $user    = $this->createMemberWithUser();
         $member  = $user->member;

--- a/tests/Feature/Controllers/MemberTransferControllerTest.php
+++ b/tests/Feature/Controllers/MemberTransferControllerTest.php
@@ -7,6 +7,7 @@ use App\Models\Division;
 use App\Models\Transfer;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Notification;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Traits\CreatesDivisions;
 use Tests\Traits\CreatesMembers;
@@ -17,7 +18,8 @@ class MemberTransferControllerTest extends TestCase
     use CreatesMembers;
     use RefreshDatabase;
 
-    public function test_member_can_request_transfer_to_another_division()
+    #[Test]
+    public function member_can_request_transfer_to_another_division()
     {
         Notification::fake();
 
@@ -42,7 +44,8 @@ class MemberTransferControllerTest extends TestCase
         ]);
     }
 
-    public function test_non_officer_transfer_is_auto_approved()
+    #[Test]
+    public function non_officer_transfer_is_auto_approved()
     {
         Notification::fake();
 
@@ -69,7 +72,8 @@ class MemberTransferControllerTest extends TestCase
         $this->assertNotNull($transfer->approved_at);
     }
 
-    public function test_officer_transfer_requires_approval()
+    #[Test]
+    public function officer_transfer_requires_approval()
     {
         Notification::fake();
 
@@ -96,7 +100,8 @@ class MemberTransferControllerTest extends TestCase
         $this->assertNull($transfer->approved_at);
     }
 
-    public function test_cannot_transfer_to_same_division()
+    #[Test]
+    public function cannot_transfer_to_same_division()
     {
         $division = $this->createActiveDivision();
 
@@ -113,7 +118,8 @@ class MemberTransferControllerTest extends TestCase
             ->assertJson(['error' => 'You cannot transfer to your current division']);
     }
 
-    public function test_cannot_transfer_if_pending_transfer_exists()
+    #[Test]
+    public function cannot_transfer_if_pending_transfer_exists()
     {
         Notification::fake();
 
@@ -139,7 +145,8 @@ class MemberTransferControllerTest extends TestCase
             ->assertJson(['error' => 'You already have a pending transfer request']);
     }
 
-    public function test_cannot_transfer_within_one_week_of_last_transfer()
+    #[Test]
+    public function cannot_transfer_within_one_week_of_last_transfer()
     {
         Notification::fake();
 
@@ -170,7 +177,8 @@ class MemberTransferControllerTest extends TestCase
         );
     }
 
-    public function test_can_transfer_after_one_week()
+    #[Test]
+    public function can_transfer_after_one_week()
     {
         Notification::fake();
 
@@ -197,7 +205,8 @@ class MemberTransferControllerTest extends TestCase
             ->assertJson(['success' => true]);
     }
 
-    public function test_cannot_transfer_to_floater_division()
+    #[Test]
+    public function cannot_transfer_to_floater_division()
     {
         $sourceDivision  = $this->createActiveDivision();
         $floaterDivision = Division::factory()->create(['name' => 'Floater', 'active' => true]);
@@ -215,7 +224,8 @@ class MemberTransferControllerTest extends TestCase
             ->assertJson(['error' => 'You cannot transfer to this division']);
     }
 
-    public function test_cannot_transfer_to_bluntz_reserves()
+    #[Test]
+    public function cannot_transfer_to_bluntz_reserves()
     {
         $sourceDivision   = $this->createActiveDivision();
         $reservesDivision = Division::factory()->create(['name' => "Bluntz' Reserves", 'active' => true]);
@@ -233,7 +243,8 @@ class MemberTransferControllerTest extends TestCase
             ->assertJson(['error' => 'You cannot transfer to this division']);
     }
 
-    public function test_cannot_transfer_from_floater_division()
+    #[Test]
+    public function cannot_transfer_from_floater_division()
     {
         $floaterDivision = Division::factory()->create(['name' => 'Floater', 'active' => true]);
         $targetDivision  = $this->createActiveDivision();
@@ -251,7 +262,8 @@ class MemberTransferControllerTest extends TestCase
             ->assertJson(['error' => 'You cannot transfer from your current division']);
     }
 
-    public function test_cannot_transfer_to_inactive_division()
+    #[Test]
+    public function cannot_transfer_to_inactive_division()
     {
         $sourceDivision   = $this->createActiveDivision();
         $inactiveDivision = Division::factory()->create(['active' => false]);
@@ -269,7 +281,8 @@ class MemberTransferControllerTest extends TestCase
             ->assertJson(['error' => 'Target division is not available for transfers']);
     }
 
-    public function test_cannot_transfer_to_shutdown_division()
+    #[Test]
+    public function cannot_transfer_to_shutdown_division()
     {
         $sourceDivision   = $this->createActiveDivision();
         $shutdownDivision = Division::factory()->create([

--- a/tests/Feature/Controllers/NoteControllerTest.php
+++ b/tests/Feature/Controllers/NoteControllerTest.php
@@ -7,6 +7,7 @@ use App\Enums\Role;
 use App\Models\DivisionTag;
 use App\Models\Note;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Traits\CreatesDivisions;
 use Tests\Traits\CreatesMembers;
@@ -17,7 +18,8 @@ class NoteControllerTest extends TestCase
     use CreatesMembers;
     use RefreshDatabase;
 
-    public function test_sr_ldr_can_restore_soft_deleted_note()
+    #[Test]
+    public function sr_ldr_can_restore_soft_deleted_note()
     {
         $srLdr    = $this->createSeniorLeader();
         $division = $srLdr->member->division;
@@ -43,7 +45,8 @@ class NoteControllerTest extends TestCase
         ]);
     }
 
-    public function test_sr_ldr_can_force_delete_soft_deleted_note()
+    #[Test]
+    public function sr_ldr_can_force_delete_soft_deleted_note()
     {
         $srLdr    = $this->createSeniorLeader();
         $division = $srLdr->member->division;
@@ -64,7 +67,8 @@ class NoteControllerTest extends TestCase
         $this->assertDatabaseMissing('notes', ['id' => $note->id]);
     }
 
-    public function test_division_leader_can_restore_soft_deleted_note()
+    #[Test]
+    public function division_leader_can_restore_soft_deleted_note()
     {
         $officer  = $this->createOfficer();
         $division = $officer->member->division;
@@ -83,7 +87,8 @@ class NoteControllerTest extends TestCase
         $response->assertJson(['success' => true]);
     }
 
-    public function test_division_leader_can_force_delete_soft_deleted_note()
+    #[Test]
+    public function division_leader_can_force_delete_soft_deleted_note()
     {
         $officer  = $this->createOfficer();
         $division = $officer->member->division;
@@ -102,7 +107,8 @@ class NoteControllerTest extends TestCase
         $response->assertJson(['success' => true]);
     }
 
-    public function test_regular_user_cannot_restore_soft_deleted_note()
+    #[Test]
+    public function regular_user_cannot_restore_soft_deleted_note()
     {
         $division = $this->createActiveDivision();
         $user     = $this->createMemberWithUser(['division_id' => $division->id]);
@@ -120,7 +126,8 @@ class NoteControllerTest extends TestCase
         $response->assertForbidden();
     }
 
-    public function test_regular_user_cannot_force_delete_soft_deleted_note()
+    #[Test]
+    public function regular_user_cannot_force_delete_soft_deleted_note()
     {
         $division = $this->createActiveDivision();
         $user     = $this->createMemberWithUser(['division_id' => $division->id]);
@@ -138,7 +145,8 @@ class NoteControllerTest extends TestCase
         $response->assertForbidden();
     }
 
-    public function test_restore_returns_404_for_nonexistent_note()
+    #[Test]
+    public function restore_returns_404_for_nonexistent_note()
     {
         $srLdr    = $this->createSeniorLeader();
         $division = $srLdr->member->division;
@@ -150,7 +158,8 @@ class NoteControllerTest extends TestCase
         $response->assertNotFound();
     }
 
-    public function test_force_delete_returns_404_for_nonexistent_note()
+    #[Test]
+    public function force_delete_returns_404_for_nonexistent_note()
     {
         $srLdr    = $this->createSeniorLeader();
         $division = $srLdr->member->division;
@@ -162,7 +171,8 @@ class NoteControllerTest extends TestCase
         $response->assertNotFound();
     }
 
-    public function test_cannot_restore_note_belonging_to_different_member()
+    #[Test]
+    public function cannot_restore_note_belonging_to_different_member()
     {
         $srLdr    = $this->createSeniorLeader();
         $division = $srLdr->member->division;
@@ -181,7 +191,8 @@ class NoteControllerTest extends TestCase
         $response->assertNotFound();
     }
 
-    public function test_admin_can_restore_soft_deleted_note()
+    #[Test]
+    public function admin_can_restore_soft_deleted_note()
     {
         $admin    = $this->createAdmin();
         $division = $this->createActiveDivision();
@@ -200,7 +211,8 @@ class NoteControllerTest extends TestCase
         $response->assertJson(['success' => true]);
     }
 
-    public function test_admin_can_force_delete_soft_deleted_note()
+    #[Test]
+    public function admin_can_force_delete_soft_deleted_note()
     {
         $admin    = $this->createAdmin();
         $division = $this->createActiveDivision();
@@ -221,7 +233,8 @@ class NoteControllerTest extends TestCase
         $this->assertDatabaseMissing('notes', ['id' => $note->id]);
     }
 
-    public function test_division_leader_can_soft_delete_note()
+    #[Test]
+    public function division_leader_can_soft_delete_note()
     {
         $officer  = $this->createOfficer();
         $division = $officer->member->division;
@@ -239,7 +252,8 @@ class NoteControllerTest extends TestCase
         $this->assertSoftDeleted('notes', ['id' => $note->id]);
     }
 
-    public function test_sr_ldr_can_soft_delete_note()
+    #[Test]
+    public function sr_ldr_can_soft_delete_note()
     {
         $srLdr    = $this->createSeniorLeader();
         $division = $srLdr->member->division;
@@ -257,7 +271,8 @@ class NoteControllerTest extends TestCase
         $this->assertSoftDeleted('notes', ['id' => $note->id]);
     }
 
-    public function test_regular_user_cannot_soft_delete_note()
+    #[Test]
+    public function regular_user_cannot_soft_delete_note()
     {
         $division = $this->createActiveDivision();
         $user     = $this->createMemberWithUser(['division_id' => $division->id]);
@@ -278,7 +293,8 @@ class NoteControllerTest extends TestCase
         ]);
     }
 
-    public function test_admin_can_soft_delete_note()
+    #[Test]
+    public function admin_can_soft_delete_note()
     {
         $admin    = $this->createAdmin();
         $division = $this->createActiveDivision();
@@ -296,7 +312,8 @@ class NoteControllerTest extends TestCase
         $this->assertSoftDeleted('notes', ['id' => $note->id]);
     }
 
-    public function test_can_create_note_with_tag()
+    #[Test]
+    public function can_create_note_with_tag()
     {
         $srLdr    = $this->createSeniorLeader();
         $division = $srLdr->member->division;
@@ -324,7 +341,8 @@ class NoteControllerTest extends TestCase
         ]);
     }
 
-    public function test_can_create_note_without_tag()
+    #[Test]
+    public function can_create_note_without_tag()
     {
         $srLdr    = $this->createSeniorLeader();
         $division = $srLdr->member->division;
@@ -344,7 +362,8 @@ class NoteControllerTest extends TestCase
         ]);
     }
 
-    public function test_platoon_leader_can_create_note_with_tag()
+    #[Test]
+    public function platoon_leader_can_create_note_with_tag()
     {
         $division = $this->createActiveDivision();
         $platoon  = $this->createPlatoon($division);
@@ -372,7 +391,8 @@ class NoteControllerTest extends TestCase
         ]);
     }
 
-    public function test_officer_can_assign_tag_when_creating_note()
+    #[Test]
+    public function officer_can_assign_tag_when_creating_note()
     {
         $division = $this->createActiveDivision();
         $user     = $this->createMemberWithUser([
@@ -405,7 +425,8 @@ class NoteControllerTest extends TestCase
         ]);
     }
 
-    public function test_cannot_assign_tag_from_different_division()
+    #[Test]
+    public function cannot_assign_tag_from_different_division()
     {
         $srLdr    = $this->createSeniorLeader();
         $division = $srLdr->member->division;
@@ -434,7 +455,8 @@ class NoteControllerTest extends TestCase
         ]);
     }
 
-    public function test_can_assign_global_tag_when_creating_note()
+    #[Test]
+    public function can_assign_global_tag_when_creating_note()
     {
         $srLdr    = $this->createSeniorLeader();
         $division = $srLdr->member->division;

--- a/tests/Feature/Controllers/RecruitingControllerTest.php
+++ b/tests/Feature/Controllers/RecruitingControllerTest.php
@@ -11,6 +11,7 @@ use App\Services\ForumProcedureService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Notification;
 use Mockery;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Traits\CreatesDivisions;
 use Tests\Traits\CreatesMembers;
@@ -56,7 +57,8 @@ class RecruitingControllerTest extends TestCase
         return $mock;
     }
 
-    public function test_index_displays_recruit_page()
+    #[Test]
+    public function index_displays_recruit_page()
     {
         $officer = $this->createOfficer();
 
@@ -68,14 +70,16 @@ class RecruitingControllerTest extends TestCase
         $response->assertViewHas('divisions');
     }
 
-    public function test_index_requires_authentication()
+    #[Test]
+    public function index_requires_authentication()
     {
         $response = $this->get(route('recruiting.initial'));
 
         $response->assertRedirect('/login');
     }
 
-    public function test_member_cannot_access_recruitment()
+    #[Test]
+    public function member_cannot_access_recruitment()
     {
         $division   = $this->createActiveDivision();
         $user       = $this->createMemberWithUser(['division_id' => $division->id]);
@@ -88,7 +92,8 @@ class RecruitingControllerTest extends TestCase
         $response->assertForbidden();
     }
 
-    public function test_form_displays_for_active_division()
+    #[Test]
+    public function form_displays_for_active_division()
     {
         $officer  = $this->createOfficer();
         $division = $this->createActiveDivision();
@@ -101,7 +106,8 @@ class RecruitingControllerTest extends TestCase
         $response->assertViewHas('division');
     }
 
-    public function test_form_redirects_for_shutdown_division()
+    #[Test]
+    public function form_redirects_for_shutdown_division()
     {
         $officer               = $this->createOfficer();
         $division              = $this->createActiveDivision();
@@ -114,7 +120,8 @@ class RecruitingControllerTest extends TestCase
         $response->assertRedirect();
     }
 
-    public function test_get_division_recruit_data_returns_json()
+    #[Test]
+    public function get_division_recruit_data_returns_json()
     {
         $officer  = $this->createOfficer();
         $division = $this->createActiveDivision();
@@ -136,7 +143,8 @@ class RecruitingControllerTest extends TestCase
         ]);
     }
 
-    public function test_submit_recruitment_creates_member()
+    #[Test]
+    public function submit_recruitment_creates_member()
     {
         $officer  = $this->createOfficer();
         $division = $this->createActiveDivision();
@@ -160,7 +168,8 @@ class RecruitingControllerTest extends TestCase
         ]);
     }
 
-    public function test_submit_recruitment_creates_transfer_record()
+    #[Test]
+    public function submit_recruitment_creates_transfer_record()
     {
         $officer  = $this->createOfficer();
         $division = $this->createActiveDivision();
@@ -180,7 +189,8 @@ class RecruitingControllerTest extends TestCase
         ]);
     }
 
-    public function test_submit_recruitment_creates_rank_action()
+    #[Test]
+    public function submit_recruitment_creates_rank_action()
     {
         $officer  = $this->createOfficer();
         $division = $this->createActiveDivision();
@@ -201,7 +211,8 @@ class RecruitingControllerTest extends TestCase
         ]);
     }
 
-    public function test_get_division_recruit_data_excludes_pending_users_without_dob(): void
+    #[Test]
+    public function get_division_recruit_data_excludes_pending_users_without_dob(): void
     {
         $officer  = $this->createOfficer();
         $division = $this->createActiveDivision();
@@ -218,7 +229,8 @@ class RecruitingControllerTest extends TestCase
         $response->assertJsonPath('pending_discord', []);
     }
 
-    public function test_get_division_recruit_data_includes_pending_users_with_dob(): void
+    #[Test]
+    public function get_division_recruit_data_includes_pending_users_with_dob(): void
     {
         $officer  = $this->createOfficer();
         $division = $this->createActiveDivision();
@@ -235,7 +247,8 @@ class RecruitingControllerTest extends TestCase
         $response->assertJsonPath('pending_discord.0.discord_username', 'ReadyUser');
     }
 
-    public function test_submit_discord_recruitment_creates_member(): void
+    #[Test]
+    public function submit_discord_recruitment_creates_member(): void
     {
         $this->mockForumUserLookup(12345);
         $this->mockProcedureService();
@@ -265,7 +278,8 @@ class RecruitingControllerTest extends TestCase
         $this->assertNotNull($pendingUser->member_id);
     }
 
-    public function test_submit_discord_recruitment_returns_error_when_forum_account_missing(): void
+    #[Test]
+    public function submit_discord_recruitment_returns_error_when_forum_account_missing(): void
     {
         $this->mockForumUserLookupFailure();
 
@@ -288,7 +302,8 @@ class RecruitingControllerTest extends TestCase
         $response->assertJsonPath('message', 'No forum account found for this user and no password is available to create one. The user may need to re-register through Discord.');
     }
 
-    public function test_submit_discord_recruitment_rejects_invalid_pending_user(): void
+    #[Test]
+    public function submit_discord_recruitment_rejects_invalid_pending_user(): void
     {
         $officer  = $this->createOfficer();
         $division = $this->createActiveDivision();
@@ -308,7 +323,8 @@ class RecruitingControllerTest extends TestCase
         $response->assertJsonPath('message', 'Pending Discord user not found.');
     }
 
-    public function test_submit_discord_recruitment_links_user_to_member(): void
+    #[Test]
+    public function submit_discord_recruitment_links_user_to_member(): void
     {
         $this->mockForumUserLookup(67890);
         $this->mockProcedureService();
@@ -336,7 +352,8 @@ class RecruitingControllerTest extends TestCase
         $this->assertFalse($pendingUser->isPendingRegistration());
     }
 
-    public function test_submit_discord_recruitment_uses_existing_forum_account(): void
+    #[Test]
+    public function submit_discord_recruitment_uses_existing_forum_account(): void
     {
         $this->mockForumUserLookup(54321);
         $this->mockProcedureService();
@@ -367,7 +384,8 @@ class RecruitingControllerTest extends TestCase
         $this->assertNotNull($pendingUser->member_id);
     }
 
-    public function test_discord_recruitment_calls_set_discord_info(): void
+    #[Test]
+    public function discord_recruitment_calls_set_discord_info(): void
     {
         $this->mockForumUserLookup(11111);
 
@@ -395,7 +413,8 @@ class RecruitingControllerTest extends TestCase
             ]);
     }
 
-    public function test_discord_recruitment_aborts_when_forum_account_not_found(): void
+    #[Test]
+    public function discord_recruitment_aborts_when_forum_account_not_found(): void
     {
         $this->mockForumUserLookup(33333);
         $this->mockProcedureService(['setDiscordInfo' => (object) ['rows_matched' => 0, 'rows_affected' => 0]]);
@@ -421,7 +440,8 @@ class RecruitingControllerTest extends TestCase
         $this->assertDatabaseMissing('members', ['name' => 'MissingForumRecruit']);
     }
 
-    public function test_discord_recruitment_blocked_by_ineligible_forum_group(): void
+    #[Test]
+    public function discord_recruitment_blocked_by_ineligible_forum_group(): void
     {
         $this->mockForumUserLookup(44444);
         $this->mockProcedureService([
@@ -448,7 +468,8 @@ class RecruitingControllerTest extends TestCase
         $this->assertDatabaseMissing('members', ['name' => 'BlockedRecruit']);
     }
 
-    public function test_validate_member_id_returns_not_found_for_unknown_id(): void
+    #[Test]
+    public function validate_member_id_returns_not_found_for_unknown_id(): void
     {
         $this->mockProcedureService(['getUser' => null]);
 
@@ -462,7 +483,8 @@ class RecruitingControllerTest extends TestCase
         ]);
     }
 
-    public function test_validate_member_id_flags_existing_tracker_member(): void
+    #[Test]
+    public function validate_member_id_flags_existing_tracker_member(): void
     {
         $existing = $this->createMember(['clan_id' => 1234]);
         $this->mockProcedureService(['getUser' => (object) [
@@ -480,7 +502,8 @@ class RecruitingControllerTest extends TestCase
         ]);
     }
 
-    public function test_validate_member_id_returns_discord_matches_from_forum_profile(): void
+    #[Test]
+    public function validate_member_id_returns_discord_matches_from_forum_profile(): void
     {
         $existingMember = $this->createMember(['discord_id' => '111222333']);
         $this->mockProcedureService(['getUser' => (object) [
@@ -497,7 +520,8 @@ class RecruitingControllerTest extends TestCase
             ->assertJsonCount(1, 'discord_matches');
     }
 
-    public function test_validate_member_id_returns_discord_matches_from_existing_tracker_member(): void
+    #[Test]
+    public function validate_member_id_returns_discord_matches_from_existing_tracker_member(): void
     {
         $existing = $this->createMember(['clan_id' => 5678, 'discord_id' => '999888777']);
         $this->mockProcedureService(['getUser' => (object) [
@@ -514,7 +538,8 @@ class RecruitingControllerTest extends TestCase
         ]);
     }
 
-    public function test_validate_member_id_excludes_self_from_discord_matches(): void
+    #[Test]
+    public function validate_member_id_excludes_self_from_discord_matches(): void
     {
         $this->createMember(['clan_id' => 7777, 'discord_id' => '777666555']);
         $this->mockProcedureService(['getUser' => (object) [
@@ -529,7 +554,8 @@ class RecruitingControllerTest extends TestCase
         $response->assertOk()->assertJson(['discord_matches' => []]);
     }
 
-    public function test_validate_member_id_returns_empty_discord_matches_when_no_discord_id(): void
+    #[Test]
+    public function validate_member_id_returns_empty_discord_matches_when_no_discord_id(): void
     {
         $this->mockProcedureService(['getUser' => (object) [
             'usergroupid' => ForumGroup::REGISTERED_USER->value,

--- a/tests/Feature/Controllers/RemoveTagScopingTest.php
+++ b/tests/Feature/Controllers/RemoveTagScopingTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Feature\Controllers;
+
+use App\Models\DivisionTag;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+use Tests\Traits\CreatesDivisions;
+use Tests\Traits\CreatesMembers;
+
+class RemoveTagScopingTest extends TestCase
+{
+    use CreatesDivisions;
+    use CreatesMembers;
+    use RefreshDatabase;
+
+    #[Test]
+    public function officer_cannot_remove_tag_belonging_to_another_division()
+    {
+        $officer       = $this->createOfficer();
+        $division      = $officer->member->division;
+        $member        = $this->createMember(['division_id' => $division->id]);
+        $otherDivision = $this->createActiveDivision();
+        $foreignTag    = DivisionTag::factory()->create(['division_id' => $otherDivision->id]);
+        $member->tags()->attach($foreignTag->id);
+
+        $this->actingAs($officer)
+            ->postJson(route('member-tags.remove', [$division->slug, $member->clan_id]), [
+                'tag_id' => $foreignTag->id,
+            ])->assertUnprocessable();
+
+        $this->assertTrue($member->fresh()->tags->contains($foreignTag));
+    }
+
+    #[Test]
+    public function officer_can_remove_tag_belonging_to_their_division()
+    {
+        $officer  = $this->createOfficer();
+        $division = $officer->member->division;
+        $member   = $this->createMember(['division_id' => $division->id]);
+        $tag      = DivisionTag::factory()->create(['division_id' => $division->id]);
+        $member->tags()->attach($tag->id);
+
+        $this->actingAs($officer)
+            ->postJson(route('member-tags.remove', [$division->slug, $member->clan_id]), [
+                'tag_id' => $tag->id,
+            ])->assertOk();
+
+        $this->assertFalse($member->fresh()->tags->contains($tag));
+    }
+
+    #[Test]
+    public function officer_can_remove_global_tag()
+    {
+        $officer   = $this->createOfficer();
+        $division  = $officer->member->division;
+        $member    = $this->createMember(['division_id' => $division->id]);
+        $globalTag = DivisionTag::factory()->global()->create();
+        $member->tags()->attach($globalTag->id);
+
+        $this->actingAs($officer)
+            ->postJson(route('member-tags.remove', [$division->slug, $member->clan_id]), [
+                'tag_id' => $globalTag->id,
+            ])->assertOk();
+
+        $this->assertFalse($member->fresh()->tags->contains($globalTag));
+    }
+}

--- a/tests/Feature/PendingActionsDataTest.php
+++ b/tests/Feature/PendingActionsDataTest.php
@@ -141,7 +141,7 @@ final class PendingActionsDataTest extends TestCase
 
         $member = Member::factory()->create(['division_id' => $this->division->id]);
         Leave::factory()->create([
-            'member_id'   => $member->clan_id,
+            'member_id'   => $member->id,
             'approver_id' => null,
         ]);
 
@@ -159,7 +159,7 @@ final class PendingActionsDataTest extends TestCase
 
         $member = Member::factory()->create(['division_id' => $this->division->id]);
         Leave::factory()->create([
-            'member_id'   => $member->clan_id,
+            'member_id'   => $member->id,
             'approver_id' => null,
         ]);
 

--- a/tests/Feature/Reports/DivisionReportControllerTest.php
+++ b/tests/Feature/Reports/DivisionReportControllerTest.php
@@ -12,6 +12,7 @@ use App\Models\RankAction;
 use App\Models\User;
 use App\Repositories\DivisionRepository;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Traits\CreatesDivisions;
 use Tests\Traits\CreatesMembers;
@@ -22,7 +23,8 @@ class DivisionReportControllerTest extends TestCase
     use CreatesMembers;
     use RefreshDatabase;
 
-    public function test_census_report_requires_authentication()
+    #[Test]
+    public function census_report_requires_authentication()
     {
         $division = $this->createActiveDivision();
 
@@ -31,7 +33,8 @@ class DivisionReportControllerTest extends TestCase
         $response->assertRedirect('/login');
     }
 
-    public function test_retention_report_requires_authentication()
+    #[Test]
+    public function retention_report_requires_authentication()
     {
         $division = $this->createActiveDivision();
 
@@ -40,7 +43,8 @@ class DivisionReportControllerTest extends TestCase
         $response->assertRedirect('/login');
     }
 
-    public function test_voice_report_requires_authentication()
+    #[Test]
+    public function voice_report_requires_authentication()
     {
         $division = $this->createActiveDivision();
 
@@ -49,7 +53,8 @@ class DivisionReportControllerTest extends TestCase
         $response->assertRedirect('/login');
     }
 
-    public function test_promotions_report_requires_authentication()
+    #[Test]
+    public function promotions_report_requires_authentication()
     {
         $division = $this->createActiveDivision();
 
@@ -58,7 +63,8 @@ class DivisionReportControllerTest extends TestCase
         $response->assertRedirect('/login');
     }
 
-    public function test_division_repository_recruits_query_uses_enum_value()
+    #[Test]
+    public function division_repository_recruits_query_uses_enum_value()
     {
         $officer  = $this->createOfficer();
         $division = $officer->member->division;
@@ -75,7 +81,8 @@ class DivisionReportControllerTest extends TestCase
         $this->assertEquals(4, $recruits->sum('recruits'));
     }
 
-    public function test_division_repository_removals_query_uses_enum_value()
+    #[Test]
+    public function division_repository_removals_query_uses_enum_value()
     {
         $officer  = $this->createOfficer();
         $division = $officer->member->division;
@@ -92,7 +99,8 @@ class DivisionReportControllerTest extends TestCase
         $this->assertEquals(3, $removals->sum('removals'));
     }
 
-    public function test_division_repository_population_query_returns_census_data()
+    #[Test]
+    public function division_repository_population_query_returns_census_data()
     {
         $officer  = $this->createOfficer();
         $division = $officer->member->division;
@@ -118,7 +126,8 @@ class DivisionReportControllerTest extends TestCase
         $this->assertGreaterThan(0, $population->count());
     }
 
-    public function test_activity_queries_work_with_integer_backed_enum()
+    #[Test]
+    public function activity_queries_work_with_integer_backed_enum()
     {
         $officer  = $this->createOfficer();
         $division = $officer->member->division;
@@ -143,7 +152,8 @@ class DivisionReportControllerTest extends TestCase
         $this->assertEquals(1, $activity->getRawOriginal('name'));
     }
 
-    public function test_activity_removed_enum_stores_correct_integer()
+    #[Test]
+    public function activity_removed_enum_stores_correct_integer()
     {
         $officer  = $this->createOfficer();
         $division = $officer->member->division;
@@ -167,7 +177,8 @@ class DivisionReportControllerTest extends TestCase
         $this->assertEquals(3, $activity->getRawOriginal('name'));
     }
 
-    public function test_recruits_and_removals_can_be_queried_together()
+    #[Test]
+    public function recruits_and_removals_can_be_queried_together()
     {
         $officer  = $this->createOfficer();
         $division = $officer->member->division;
@@ -187,7 +198,8 @@ class DivisionReportControllerTest extends TestCase
         $this->assertEquals(3, $recruits->sum('recruits') - $removals->sum('removals'));
     }
 
-    public function test_recruits_query_filters_by_date_range()
+    #[Test]
+    public function recruits_query_filters_by_date_range()
     {
         $officer  = $this->createOfficer();
         $division = $officer->member->division;
@@ -204,7 +216,8 @@ class DivisionReportControllerTest extends TestCase
         $this->assertEquals(3, $recruits->sum('recruits'));
     }
 
-    public function test_removals_query_filters_by_date_range()
+    #[Test]
+    public function removals_query_filters_by_date_range()
     {
         $officer  = $this->createOfficer();
         $division = $officer->member->division;
@@ -221,7 +234,8 @@ class DivisionReportControllerTest extends TestCase
         $this->assertEquals(4, $removals->sum('removals'));
     }
 
-    public function test_recruits_query_filters_by_division()
+    #[Test]
+    public function recruits_query_filters_by_division()
     {
         $officer       = $this->createOfficer();
         $division      = $officer->member->division;
@@ -239,7 +253,8 @@ class DivisionReportControllerTest extends TestCase
         $this->assertEquals(3, $recruits->sum('recruits'));
     }
 
-    public function test_rank_action_approved_can_be_queried()
+    #[Test]
+    public function rank_action_approved_can_be_queried()
     {
         $officer  = $this->createOfficer();
         $division = $officer->member->division;
@@ -257,7 +272,8 @@ class DivisionReportControllerTest extends TestCase
         $this->assertEquals(1, $approvedActions->count());
     }
 
-    public function test_census_data_can_be_created_and_queried()
+    #[Test]
+    public function census_data_can_be_created_and_queried()
     {
         $officer  = $this->createOfficer();
         $division = $officer->member->division;
@@ -276,7 +292,8 @@ class DivisionReportControllerTest extends TestCase
         $this->assertEquals(75, $census->weekly_voice_count);
     }
 
-    public function test_members_with_discord_issues_can_be_queried()
+    #[Test]
+    public function members_with_discord_issues_can_be_queried()
     {
         $officer  = $this->createOfficer();
         $division = $officer->member->division;

--- a/tests/Feature/Reports/ReportsControllerTest.php
+++ b/tests/Feature/Reports/ReportsControllerTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Reports;
 
 use App\Exceptions\FactoryMissingException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Traits\CreatesDivisions;
 use Tests\Traits\CreatesMembers;
@@ -14,14 +15,16 @@ class ReportsControllerTest extends TestCase
     use CreatesMembers;
     use RefreshDatabase;
 
-    public function test_clan_census_report_requires_authentication()
+    #[Test]
+    public function clan_census_report_requires_authentication()
     {
         $response = $this->get(route('reports.clan-census'));
 
         $response->assertRedirect('/login');
     }
 
-    public function test_clan_census_throws_exception_without_census_data()
+    #[Test]
+    public function clan_census_throws_exception_without_census_data()
     {
         $officer = $this->createOfficer();
 
@@ -32,7 +35,8 @@ class ReportsControllerTest extends TestCase
             ->get(route('reports.clan-census'));
     }
 
-    public function test_outstanding_inactives_report_displays()
+    #[Test]
+    public function outstanding_inactives_report_displays()
     {
         $officer = $this->createOfficer();
 
@@ -42,14 +46,16 @@ class ReportsControllerTest extends TestCase
         $response->assertOk();
     }
 
-    public function test_outstanding_inactives_requires_authentication()
+    #[Test]
+    public function outstanding_inactives_requires_authentication()
     {
         $response = $this->get(route('reports.outstanding-inactives'));
 
         $response->assertRedirect('/login');
     }
 
-    public function test_leadership_report_displays()
+    #[Test]
+    public function leadership_report_displays()
     {
         $officer = $this->createOfficer();
 
@@ -59,14 +65,16 @@ class ReportsControllerTest extends TestCase
         $response->assertOk();
     }
 
-    public function test_leadership_report_requires_authentication()
+    #[Test]
+    public function leadership_report_requires_authentication()
     {
         $response = $this->get(route('leadership'));
 
         $response->assertRedirect('/login');
     }
 
-    public function test_division_turnover_report_displays_for_admin()
+    #[Test]
+    public function division_turnover_report_displays_for_admin()
     {
         $admin = $this->createAdmin();
 
@@ -76,7 +84,8 @@ class ReportsControllerTest extends TestCase
         $response->assertOk();
     }
 
-    public function test_division_turnover_requires_admin_role()
+    #[Test]
+    public function division_turnover_requires_admin_role()
     {
         $officer = $this->createOfficer();
 

--- a/tests/Traits/CreatesPendingActionItems.php
+++ b/tests/Traits/CreatesPendingActionItems.php
@@ -33,7 +33,7 @@ trait CreatesPendingActionItems
         foreach ($members as $member) {
             MemberAward::factory()->pending()->create([
                 'award_id'  => $award->id,
-                'member_id' => $member->clan_id,
+                'member_id' => $member->id,
             ]);
         }
     }
@@ -63,7 +63,7 @@ trait CreatesPendingActionItems
 
         foreach ($members as $member) {
             Leave::factory()->create([
-                'member_id'   => $member->clan_id,
+                'member_id'   => $member->id,
                 'approver_id' => null,
             ]);
         }

--- a/tests/Unit/Jobs/AddClanMemberTest.php
+++ b/tests/Unit/Jobs/AddClanMemberTest.php
@@ -8,6 +8,7 @@ use App\Services\ForumProcedureService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
 use Mockery;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Traits\CreatesDivisions;
 use Tests\Traits\CreatesMembers;
@@ -29,7 +30,8 @@ class AddClanMemberTest extends TestCase
         $this->procedureService->shouldReceive('setDiscordInfo')->byDefault()->andReturn((object) ['rows_matched' => 1, 'rows_affected' => 1]);
     }
 
-    public function test_job_can_be_instantiated()
+    #[Test]
+    public function job_can_be_instantiated()
     {
         $division = $this->createActiveDivision();
         $member   = $this->createMember(['division_id' => $division->id]);
@@ -39,7 +41,8 @@ class AddClanMemberTest extends TestCase
         $this->assertInstanceOf(AddClanMember::class, $job);
     }
 
-    public function test_job_calls_forum_service_with_correct_parameters()
+    #[Test]
+    public function job_calls_forum_service_with_correct_parameters()
     {
         Http::fake([
             '*' => Http::response('saved_user_x_successfully', 200),
@@ -61,7 +64,8 @@ class AddClanMemberTest extends TestCase
         });
     }
 
-    public function test_job_includes_aod_prefix_in_member_name()
+    #[Test]
+    public function job_includes_aod_prefix_in_member_name()
     {
         Http::fake([
             '*' => Http::response('saved_user_x_successfully', 200),
@@ -81,7 +85,8 @@ class AddClanMemberTest extends TestCase
         });
     }
 
-    public function test_job_throws_exception_on_failure()
+    #[Test]
+    public function job_throws_exception_on_failure()
     {
         Http::fake([
             '*' => Http::response('error_invalid_user', 200),
@@ -96,7 +101,8 @@ class AddClanMemberTest extends TestCase
         $job->handle($this->procedureService);
     }
 
-    public function test_job_diagnoses_banned_user_on_failure()
+    #[Test]
+    public function job_diagnoses_banned_user_on_failure()
     {
         Http::fake([
             '*' => Http::response('error_invalid_user', 200),
@@ -116,7 +122,8 @@ class AddClanMemberTest extends TestCase
         $job->handle($this->procedureService);
     }
 
-    public function test_job_sets_discord_info_before_adding_member(): void
+    #[Test]
+    public function job_sets_discord_info_before_adding_member(): void
     {
         Http::fake([
             '*' => Http::response('saved_user_x_successfully', 200),
@@ -148,7 +155,8 @@ class AddClanMemberTest extends TestCase
         Http::assertSent(fn ($req) => str_contains($req->url(), 'do=addaod'));
     }
 
-    public function test_job_diagnoses_awaiting_email_on_failure()
+    #[Test]
+    public function job_diagnoses_awaiting_email_on_failure()
     {
         Http::fake([
             '*' => Http::response('error_invalid_user', 200),

--- a/tests/Unit/Jobs/CleanupUnassignedLeadersTest.php
+++ b/tests/Unit/Jobs/CleanupUnassignedLeadersTest.php
@@ -6,6 +6,7 @@ use App\Enums\Position;
 use App\Jobs\CleanupUnassignedLeaders;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Traits\CreatesDivisions;
 use Tests\Traits\CreatesMembers;
@@ -16,7 +17,8 @@ class CleanupUnassignedLeadersTest extends TestCase
     use CreatesMembers;
     use RefreshDatabase;
 
-    public function test_resets_unassigned_squad_leaders_to_member()
+    #[Test]
+    public function resets_unassigned_squad_leaders_to_member()
     {
         $division = $this->createActiveDivision();
 
@@ -32,7 +34,8 @@ class CleanupUnassignedLeadersTest extends TestCase
         $this->assertEquals(Position::MEMBER, $member->position);
     }
 
-    public function test_resets_unassigned_platoon_leaders_to_member()
+    #[Test]
+    public function resets_unassigned_platoon_leaders_to_member()
     {
         $division = $this->createActiveDivision();
 
@@ -48,7 +51,8 @@ class CleanupUnassignedLeadersTest extends TestCase
         $this->assertEquals(Position::MEMBER, $member->position);
     }
 
-    public function test_does_not_affect_assigned_squad_leaders()
+    #[Test]
+    public function does_not_affect_assigned_squad_leaders()
     {
         $division = $this->createActiveDivision();
         $platoon  = $this->createPlatoon($division);
@@ -63,7 +67,8 @@ class CleanupUnassignedLeadersTest extends TestCase
         $this->assertEquals(Position::SQUAD_LEADER, $leader->position);
     }
 
-    public function test_does_not_affect_assigned_platoon_leaders()
+    #[Test]
+    public function does_not_affect_assigned_platoon_leaders()
     {
         $division = $this->createActiveDivision();
         $platoon  = $this->createPlatoon($division);
@@ -77,7 +82,8 @@ class CleanupUnassignedLeadersTest extends TestCase
         $this->assertEquals(Position::PLATOON_LEADER, $leader->position);
     }
 
-    public function test_does_not_affect_regular_members()
+    #[Test]
+    public function does_not_affect_regular_members()
     {
         $division = $this->createActiveDivision();
 
@@ -93,7 +99,8 @@ class CleanupUnassignedLeadersTest extends TestCase
         $this->assertEquals(Position::MEMBER, $member->position);
     }
 
-    public function test_does_not_affect_higher_positions()
+    #[Test]
+    public function does_not_affect_higher_positions()
     {
         $division = $this->createActiveDivision();
 
@@ -116,7 +123,8 @@ class CleanupUnassignedLeadersTest extends TestCase
         $this->assertEquals(Position::COMMANDING_OFFICER, $co->position);
     }
 
-    public function test_job_is_queueable()
+    #[Test]
+    public function job_is_queueable()
     {
         $job = new CleanupUnassignedLeaders;
 

--- a/tests/Unit/Jobs/PartTimeMemberCleanupTest.php
+++ b/tests/Unit/Jobs/PartTimeMemberCleanupTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Jobs;
 use App\Jobs\PartTimeMemberCleanup;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Traits\CreatesDivisions;
 use Tests\Traits\CreatesMembers;
@@ -15,7 +16,8 @@ class PartTimeMemberCleanupTest extends TestCase
     use CreatesMembers;
     use RefreshDatabase;
 
-    public function test_removes_part_time_entry_matching_full_time_division()
+    #[Test]
+    public function removes_part_time_entry_matching_full_time_division()
     {
         $division = $this->createActiveDivision();
 
@@ -34,7 +36,8 @@ class PartTimeMemberCleanupTest extends TestCase
         $this->assertCount(0, $member->partTimeDivisions);
     }
 
-    public function test_keeps_part_time_entries_for_different_divisions()
+    #[Test]
+    public function keeps_part_time_entries_for_different_divisions()
     {
         $fullTimeDivision = $this->createActiveDivision();
         $partTimeDivision = $this->createActiveDivision();
@@ -53,7 +56,8 @@ class PartTimeMemberCleanupTest extends TestCase
         $this->assertEquals($partTimeDivision->id, $member->partTimeDivisions->first()->id);
     }
 
-    public function test_removes_only_matching_division_keeps_others()
+    #[Test]
+    public function removes_only_matching_division_keeps_others()
     {
         $fullTimeDivision = $this->createActiveDivision();
         $partTimeDivision = $this->createActiveDivision();
@@ -77,7 +81,8 @@ class PartTimeMemberCleanupTest extends TestCase
         $this->assertEquals($partTimeDivision->id, $member->partTimeDivisions->first()->id);
     }
 
-    public function test_does_not_affect_members_without_division()
+    #[Test]
+    public function does_not_affect_members_without_division()
     {
         $tempDivision     = $this->createActiveDivision();
         $partTimeDivision = $this->createActiveDivision();
@@ -96,7 +101,8 @@ class PartTimeMemberCleanupTest extends TestCase
         $this->assertCount(1, $member->partTimeDivisions);
     }
 
-    public function test_does_not_affect_members_without_part_time_divisions()
+    #[Test]
+    public function does_not_affect_members_without_part_time_divisions()
     {
         $division = $this->createActiveDivision();
 
@@ -111,7 +117,8 @@ class PartTimeMemberCleanupTest extends TestCase
         $this->assertCount(0, $member->partTimeDivisions);
     }
 
-    public function test_job_is_queueable()
+    #[Test]
+    public function job_is_queueable()
     {
         $job = new PartTimeMemberCleanup;
 

--- a/tests/Unit/Jobs/RemoveClanMemberTest.php
+++ b/tests/Unit/Jobs/RemoveClanMemberTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Jobs;
 use App\Jobs\RemoveClanMember;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class RemoveClanMemberTest extends TestCase
@@ -17,14 +18,16 @@ class RemoveClanMemberTest extends TestCase
         config(['aod.token' => 'test-token']);
     }
 
-    public function test_job_can_be_instantiated()
+    #[Test]
+    public function job_can_be_instantiated()
     {
         $job = new RemoveClanMember(12345, 67890);
 
         $this->assertInstanceOf(RemoveClanMember::class, $job);
     }
 
-    public function test_job_calls_forum_service_with_correct_parameters()
+    #[Test]
+    public function job_calls_forum_service_with_correct_parameters()
     {
         Http::fake([
             '*' => Http::response('saved_user_x_successfully', 200),
@@ -45,7 +48,8 @@ class RemoveClanMemberTest extends TestCase
         });
     }
 
-    public function test_job_throws_exception_on_failure()
+    #[Test]
+    public function job_throws_exception_on_failure()
     {
         Http::fake([
             '*' => Http::response('error_user_not_found', 200),

--- a/tests/Unit/Jobs/ResetOrphanedUnitAssignmentsTest.php
+++ b/tests/Unit/Jobs/ResetOrphanedUnitAssignmentsTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Jobs;
 use App\Jobs\ResetOrphanedUnitAssignments;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Traits\CreatesDivisions;
 use Tests\Traits\CreatesMembers;
@@ -15,7 +16,8 @@ class ResetOrphanedUnitAssignmentsTest extends TestCase
     use CreatesMembers;
     use RefreshDatabase;
 
-    public function test_resets_platoon_and_squad_for_member_with_zero_division()
+    #[Test]
+    public function resets_platoon_and_squad_for_member_with_zero_division()
     {
         $division = $this->createActiveDivision();
         $platoon  = $this->createPlatoon($division);
@@ -37,7 +39,8 @@ class ResetOrphanedUnitAssignmentsTest extends TestCase
         $this->assertEquals(0, $member->squad_id);
     }
 
-    public function test_does_not_affect_members_with_valid_division()
+    #[Test]
+    public function does_not_affect_members_with_valid_division()
     {
         $division = $this->createActiveDivision();
         $platoon  = $this->createPlatoon($division);
@@ -57,7 +60,8 @@ class ResetOrphanedUnitAssignmentsTest extends TestCase
         $this->assertEquals($squad->id, $member->squad_id);
     }
 
-    public function test_does_not_affect_members_without_unit_assignments()
+    #[Test]
+    public function does_not_affect_members_without_unit_assignments()
     {
         $division = $this->createActiveDivision();
 
@@ -77,7 +81,8 @@ class ResetOrphanedUnitAssignmentsTest extends TestCase
         $this->assertEquals(0, $member->squad_id);
     }
 
-    public function test_job_is_queueable()
+    #[Test]
+    public function job_is_queueable()
     {
         $job = new ResetOrphanedUnitAssignments;
 

--- a/tests/Unit/Jobs/SyncDiscordMemberTest.php
+++ b/tests/Unit/Jobs/SyncDiscordMemberTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Jobs;
 use App\Jobs\SyncDiscordMember;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Traits\CreatesDivisions;
 use Tests\Traits\CreatesMembers;
@@ -15,7 +16,8 @@ class SyncDiscordMemberTest extends TestCase
     use CreatesMembers;
     use RefreshDatabase;
 
-    public function test_job_can_be_instantiated()
+    #[Test]
+    public function job_can_be_instantiated()
     {
         $division = $this->createActiveDivision();
         $member   = $this->createMember(['division_id' => $division->id]);
@@ -25,7 +27,8 @@ class SyncDiscordMemberTest extends TestCase
         $this->assertInstanceOf(SyncDiscordMember::class, $job);
     }
 
-    public function test_job_stores_member_reference()
+    #[Test]
+    public function job_stores_member_reference()
     {
         $division = $this->createActiveDivision();
         $member   = $this->createMember(['division_id' => $division->id]);
@@ -35,7 +38,8 @@ class SyncDiscordMemberTest extends TestCase
         $this->assertEquals($member->id, $job->member->id);
     }
 
-    public function test_job_is_queueable()
+    #[Test]
+    public function job_is_queueable()
     {
         $division = $this->createActiveDivision();
         $member   = $this->createMember(['division_id' => $division->id]);
@@ -48,7 +52,8 @@ class SyncDiscordMemberTest extends TestCase
         ));
     }
 
-    public function test_member_discord_fields_can_be_updated()
+    #[Test]
+    public function member_discord_fields_can_be_updated()
     {
         $division = $this->createActiveDivision();
         $member   = $this->createMember([
@@ -66,7 +71,8 @@ class SyncDiscordMemberTest extends TestCase
         $this->assertEquals('TestUser#1234', $member->discord);
     }
 
-    public function test_member_is_dirty_when_discord_fields_change()
+    #[Test]
+    public function member_is_dirty_when_discord_fields_change()
     {
         $division = $this->createActiveDivision();
         $member   = $this->createMember([
@@ -81,7 +87,8 @@ class SyncDiscordMemberTest extends TestCase
         $this->assertTrue($member->isDirty());
     }
 
-    public function test_member_is_not_dirty_when_no_changes()
+    #[Test]
+    public function member_is_not_dirty_when_no_changes()
     {
         $division = $this->createActiveDivision();
         $member   = $this->createMember([

--- a/tests/Unit/Jobs/UpdateDivisionForMemberTest.php
+++ b/tests/Unit/Jobs/UpdateDivisionForMemberTest.php
@@ -6,6 +6,7 @@ use App\Jobs\UpdateDivisionForMember;
 use App\Models\Transfer;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Traits\CreatesDivisions;
 use Tests\Traits\CreatesMembers;
@@ -16,7 +17,8 @@ class UpdateDivisionForMemberTest extends TestCase
     use CreatesMembers;
     use RefreshDatabase;
 
-    public function test_job_can_be_instantiated()
+    #[Test]
+    public function job_can_be_instantiated()
     {
         $fromDivision = $this->createActiveDivision();
         $toDivision   = $this->createActiveDivision();
@@ -32,7 +34,8 @@ class UpdateDivisionForMemberTest extends TestCase
         $this->assertInstanceOf(UpdateDivisionForMember::class, $job);
     }
 
-    public function test_job_stores_transfer_reference()
+    #[Test]
+    public function job_stores_transfer_reference()
     {
         $fromDivision = $this->createActiveDivision();
         $toDivision   = $this->createActiveDivision();
@@ -48,7 +51,8 @@ class UpdateDivisionForMemberTest extends TestCase
         $this->assertEquals($transfer->id, $job->transfer->id);
     }
 
-    public function test_job_accesses_member_clan_id_from_transfer()
+    #[Test]
+    public function job_accesses_member_clan_id_from_transfer()
     {
         $fromDivision = $this->createActiveDivision();
         $toDivision   = $this->createActiveDivision();
@@ -67,7 +71,8 @@ class UpdateDivisionForMemberTest extends TestCase
         $this->assertEquals(99999, $job->transfer->member->clan_id);
     }
 
-    public function test_job_accesses_division_name_from_transfer()
+    #[Test]
+    public function job_accesses_division_name_from_transfer()
     {
         $fromDivision = $this->createActiveDivision();
         $toDivision   = $this->createActiveDivision(['name' => 'Target Division']);
@@ -83,7 +88,8 @@ class UpdateDivisionForMemberTest extends TestCase
         $this->assertEquals('Target Division', $job->transfer->division->name);
     }
 
-    public function test_job_is_queueable()
+    #[Test]
+    public function job_is_queueable()
     {
         $fromDivision = $this->createActiveDivision();
         $toDivision   = $this->createActiveDivision();

--- a/tests/Unit/Jobs/UpdateRankForMemberTest.php
+++ b/tests/Unit/Jobs/UpdateRankForMemberTest.php
@@ -10,6 +10,7 @@ use App\Services\ForumProcedureService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Notification;
 use Mockery;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Traits\CreatesDivisions;
 use Tests\Traits\CreatesMembers;
@@ -32,7 +33,8 @@ class UpdateRankForMemberTest extends TestCase
         $this->procedureService->shouldReceive('setUserRank')->andReturn(null);
     }
 
-    public function test_job_can_be_instantiated()
+    #[Test]
+    public function job_can_be_instantiated()
     {
         $division = $this->createActiveDivision();
         $member   = $this->createMember([
@@ -50,7 +52,8 @@ class UpdateRankForMemberTest extends TestCase
         $this->assertInstanceOf(UpdateRankForMember::class, $job);
     }
 
-    public function test_job_updates_member_rank()
+    #[Test]
+    public function job_updates_member_rank()
     {
         $division = $this->createActiveDivision();
         $member   = $this->createMember([
@@ -70,7 +73,8 @@ class UpdateRankForMemberTest extends TestCase
         $this->assertEquals(Rank::CORPORAL, $member->rank);
     }
 
-    public function test_job_updates_last_promoted_at_on_promotion()
+    #[Test]
+    public function job_updates_last_promoted_at_on_promotion()
     {
         $division = $this->createActiveDivision();
         $member   = $this->createMember([
@@ -91,7 +95,8 @@ class UpdateRankForMemberTest extends TestCase
         $this->assertNotNull($member->last_promoted_at);
     }
 
-    public function test_job_does_not_update_last_promoted_at_on_demotion()
+    #[Test]
+    public function job_does_not_update_last_promoted_at_on_demotion()
     {
         $division     = $this->createActiveDivision();
         $originalDate = now()->subYear();
@@ -116,7 +121,8 @@ class UpdateRankForMemberTest extends TestCase
         );
     }
 
-    public function test_job_sends_division_notification_on_promotion()
+    #[Test]
+    public function job_sends_division_notification_on_promotion()
     {
         $division = $this->createActiveDivision();
         $member   = $this->createMember([
@@ -135,7 +141,8 @@ class UpdateRankForMemberTest extends TestCase
         Notification::assertSentTo($division, NotifyDivisionMemberPromotion::class);
     }
 
-    public function test_job_does_not_send_promotion_notification_on_demotion()
+    #[Test]
+    public function job_does_not_send_promotion_notification_on_demotion()
     {
         $division = $this->createActiveDivision();
         $member   = $this->createMember([

--- a/tests/Unit/Models/AwardTest.php
+++ b/tests/Unit/Models/AwardTest.php
@@ -94,19 +94,19 @@ class AwardTest extends TestCase
         $member2 = $this->createMember(['division_id' => $division->id]);
 
         MemberAward::factory()->approved()->create([
-            'member_id' => $member1->clan_id,
+            'member_id' => $member1->id,
             'award_id'  => $award->id,
         ]);
 
         MemberAward::factory()->pending()->create([
-            'member_id' => $member2->clan_id,
+            'member_id' => $member2->id,
             'award_id'  => $award->id,
         ]);
 
         $recipients = $award->recipients;
 
         $this->assertCount(1, $recipients);
-        $this->assertEquals($member1->clan_id, $recipients->first()->member_id);
+        $this->assertEquals($member1->id, $recipients->first()->member_id);
     }
 
     public function test_unapproved_recipients_returns_only_pending_awards()
@@ -118,19 +118,19 @@ class AwardTest extends TestCase
         $member2 = $this->createMember(['division_id' => $division->id]);
 
         MemberAward::factory()->approved()->create([
-            'member_id' => $member1->clan_id,
+            'member_id' => $member1->id,
             'award_id'  => $award->id,
         ]);
 
         MemberAward::factory()->pending()->create([
-            'member_id' => $member2->clan_id,
+            'member_id' => $member2->id,
             'award_id'  => $award->id,
         ]);
 
         $unapproved = $award->unapprovedRecipients;
 
         $this->assertCount(1, $unapproved);
-        $this->assertEquals($member2->clan_id, $unapproved->first()->member_id);
+        $this->assertEquals($member2->id, $unapproved->first()->member_id);
     }
 
     public function test_division_relationship_returns_correct_division()
@@ -148,7 +148,7 @@ class AwardTest extends TestCase
         $member   = $this->createMember(['division_id' => $division->id]);
 
         $memberAward = MemberAward::factory()->approved()->create([
-            'member_id' => $member->clan_id,
+            'member_id' => $member->id,
             'award_id'  => $award->id,
         ]);
 
@@ -187,7 +187,7 @@ class AwardTest extends TestCase
         $member = $this->createMember(['division_id' => $division->id]);
 
         MemberAward::factory()->approved()->create([
-            'member_id' => $member->clan_id,
+            'member_id' => $member->id,
             'award_id'  => $award->id,
         ]);
 
@@ -210,7 +210,7 @@ class AwardTest extends TestCase
         $member = $this->createMember(['division_id' => $division->id]);
 
         MemberAward::factory()->approved()->create([
-            'member_id' => $member->clan_id,
+            'member_id' => $member->id,
             'award_id'  => $award->id,
         ]);
 
@@ -249,16 +249,16 @@ class AwardTest extends TestCase
         $member = $this->createMember(['division_id' => $division->id]);
 
         MemberAward::factory()->approved()->create([
-            'member_id' => $member->clan_id,
+            'member_id' => $member->id,
             'award_id'  => $award->id,
         ]);
 
         MemberAward::factory()->approved()->create([
-            'member_id' => $member->clan_id,
+            'member_id' => $member->id,
             'award_id'  => $award->id,
         ]);
 
-        $this->assertCount(2, MemberAward::where('member_id', $member->clan_id)
+        $this->assertCount(2, MemberAward::where('member_id', $member->id)
             ->where('award_id', $award->id)
             ->get());
     }
@@ -359,7 +359,7 @@ class AwardTest extends TestCase
         $member = $this->createMember(['division_id' => $division->id]);
 
         MemberAward::factory()->approved()->create([
-            'member_id' => $member->clan_id,
+            'member_id' => $member->id,
             'award_id'  => $tier2->id,
         ]);
 
@@ -381,19 +381,19 @@ class AwardTest extends TestCase
         $memberWithoutDivision->update(['division_id' => 0]);
 
         MemberAward::factory()->approved()->create([
-            'member_id' => $memberWithDivision->clan_id,
+            'member_id' => $memberWithDivision->id,
             'award_id'  => $award->id,
         ]);
 
         MemberAward::factory()->approved()->create([
-            'member_id' => $memberWithoutDivision->clan_id,
+            'member_id' => $memberWithoutDivision->id,
             'award_id'  => $award->id,
         ]);
 
         $recipients = $award->recipients;
 
         $this->assertCount(1, $recipients);
-        $this->assertEquals($memberWithDivision->clan_id, $recipients->first()->member_id);
+        $this->assertEquals($memberWithDivision->id, $recipients->first()->member_id);
     }
 
     public function test_recipients_count_excludes_members_without_division()
@@ -406,12 +406,12 @@ class AwardTest extends TestCase
         $memberWithoutDivision->update(['division_id' => 0]);
 
         MemberAward::factory()->approved()->create([
-            'member_id' => $memberWithDivision->clan_id,
+            'member_id' => $memberWithDivision->id,
             'award_id'  => $award->id,
         ]);
 
         MemberAward::factory()->approved()->create([
-            'member_id' => $memberWithoutDivision->clan_id,
+            'member_id' => $memberWithoutDivision->id,
             'award_id'  => $award->id,
         ]);
 

--- a/tests/Unit/Models/AwardTest.php
+++ b/tests/Unit/Models/AwardTest.php
@@ -7,6 +7,7 @@ use App\Models\MemberAward;
 use App\Rules\UniqueAwardForMember;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Validator;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Traits\CreatesDivisions;
 use Tests\Traits\CreatesMembers;
@@ -17,7 +18,8 @@ class AwardTest extends TestCase
     use CreatesMembers;
     use RefreshDatabase;
 
-    public function test_get_rarity_returns_mythic_for_one_recipient()
+    #[Test]
+    public function get_rarity_returns_mythic_for_one_recipient()
     {
         $division = $this->createActiveDivision();
         $award    = Award::factory()->create(['division_id' => $division->id]);
@@ -25,7 +27,8 @@ class AwardTest extends TestCase
         $this->assertEquals('mythic', $award->getRarity(1));
     }
 
-    public function test_get_rarity_returns_legendary_for_few_recipients()
+    #[Test]
+    public function get_rarity_returns_legendary_for_few_recipients()
     {
         $division = $this->createActiveDivision();
         $award    = Award::factory()->create(['division_id' => $division->id]);
@@ -33,7 +36,8 @@ class AwardTest extends TestCase
         $this->assertEquals('legendary', $award->getRarity(10));
     }
 
-    public function test_get_rarity_returns_epic_for_moderate_recipients()
+    #[Test]
+    public function get_rarity_returns_epic_for_moderate_recipients()
     {
         $division = $this->createActiveDivision();
         $award    = Award::factory()->create(['division_id' => $division->id]);
@@ -41,7 +45,8 @@ class AwardTest extends TestCase
         $this->assertEquals('epic', $award->getRarity(25));
     }
 
-    public function test_get_rarity_returns_rare_for_many_recipients()
+    #[Test]
+    public function get_rarity_returns_rare_for_many_recipients()
     {
         $division = $this->createActiveDivision();
         $award    = Award::factory()->create(['division_id' => $division->id]);
@@ -49,7 +54,8 @@ class AwardTest extends TestCase
         $this->assertEquals('rare', $award->getRarity(50));
     }
 
-    public function test_get_rarity_returns_common_for_lots_of_recipients()
+    #[Test]
+    public function get_rarity_returns_common_for_lots_of_recipients()
     {
         $division = $this->createActiveDivision();
         $award    = Award::factory()->create(['division_id' => $division->id]);
@@ -57,7 +63,8 @@ class AwardTest extends TestCase
         $this->assertEquals('common', $award->getRarity(100));
     }
 
-    public function test_get_rarity_uses_recipients_count_attribute_when_available()
+    #[Test]
+    public function get_rarity_uses_recipients_count_attribute_when_available()
     {
         $division                = $this->createActiveDivision();
         $award                   = Award::factory()->create(['division_id' => $division->id]);
@@ -66,7 +73,8 @@ class AwardTest extends TestCase
         $this->assertEquals('mythic', $award->getRarity());
     }
 
-    public function test_scope_active_returns_only_active_awards()
+    #[Test]
+    public function scope_active_returns_only_active_awards()
     {
         $division = $this->createActiveDivision();
 
@@ -85,7 +93,8 @@ class AwardTest extends TestCase
         $this->assertFalse($results->contains($inactiveAward));
     }
 
-    public function test_recipients_returns_only_approved_awards()
+    #[Test]
+    public function recipients_returns_only_approved_awards()
     {
         $division = $this->createActiveDivision();
         $award    = Award::factory()->create(['division_id' => $division->id]);
@@ -109,7 +118,8 @@ class AwardTest extends TestCase
         $this->assertEquals($member1->id, $recipients->first()->member_id);
     }
 
-    public function test_unapproved_recipients_returns_only_pending_awards()
+    #[Test]
+    public function unapproved_recipients_returns_only_pending_awards()
     {
         $division = $this->createActiveDivision();
         $award    = Award::factory()->create(['division_id' => $division->id]);
@@ -133,7 +143,8 @@ class AwardTest extends TestCase
         $this->assertEquals($member2->id, $unapproved->first()->member_id);
     }
 
-    public function test_division_relationship_returns_correct_division()
+    #[Test]
+    public function division_relationship_returns_correct_division()
     {
         $division = $this->createActiveDivision();
         $award    = Award::factory()->create(['division_id' => $division->id]);
@@ -141,7 +152,8 @@ class AwardTest extends TestCase
         $this->assertTrue($award->division->is($division));
     }
 
-    public function test_deleting_award_soft_deletes_and_removes_recipients()
+    #[Test]
+    public function deleting_award_soft_deletes_and_removes_recipients()
     {
         $division = $this->createActiveDivision();
         $award    = Award::factory()->create(['division_id' => $division->id]);
@@ -158,7 +170,8 @@ class AwardTest extends TestCase
         $this->assertDatabaseMissing('award_member', ['id' => $memberAward->id]);
     }
 
-    public function test_repeatable_attribute_defaults_to_false()
+    #[Test]
+    public function repeatable_attribute_defaults_to_false()
     {
         $division = $this->createActiveDivision();
         $award    = Award::factory()->create(['division_id' => $division->id]);
@@ -166,7 +179,8 @@ class AwardTest extends TestCase
         $this->assertFalse($award->repeatable);
     }
 
-    public function test_repeatable_attribute_can_be_set_to_true()
+    #[Test]
+    public function repeatable_attribute_can_be_set_to_true()
     {
         $division = $this->createActiveDivision();
         $award    = Award::factory()->create([
@@ -177,7 +191,8 @@ class AwardTest extends TestCase
         $this->assertTrue($award->repeatable);
     }
 
-    public function test_unique_award_rule_fails_for_non_repeatable_award_when_member_already_has_it()
+    #[Test]
+    public function unique_award_rule_fails_for_non_repeatable_award_when_member_already_has_it()
     {
         $division = $this->createActiveDivision();
         $award    = Award::factory()->create([
@@ -200,7 +215,8 @@ class AwardTest extends TestCase
         $this->assertArrayHasKey('member_id', $validator->errors()->toArray());
     }
 
-    public function test_unique_award_rule_passes_for_repeatable_award_when_member_already_has_it()
+    #[Test]
+    public function unique_award_rule_passes_for_repeatable_award_when_member_already_has_it()
     {
         $division = $this->createActiveDivision();
         $award    = Award::factory()->create([
@@ -222,7 +238,8 @@ class AwardTest extends TestCase
         $this->assertFalse($validator->fails());
     }
 
-    public function test_unique_award_rule_passes_for_new_member()
+    #[Test]
+    public function unique_award_rule_passes_for_new_member()
     {
         $division = $this->createActiveDivision();
         $award    = Award::factory()->create([
@@ -239,7 +256,8 @@ class AwardTest extends TestCase
         $this->assertFalse($validator->fails());
     }
 
-    public function test_member_can_have_multiple_instances_of_repeatable_award()
+    #[Test]
+    public function member_can_have_multiple_instances_of_repeatable_award()
     {
         $division = $this->createActiveDivision();
         $award    = Award::factory()->create([
@@ -263,7 +281,8 @@ class AwardTest extends TestCase
             ->get());
     }
 
-    public function test_is_part_of_tiered_group_returns_true_when_has_prerequisite()
+    #[Test]
+    public function is_part_of_tiered_group_returns_true_when_has_prerequisite()
     {
         $division = $this->createActiveDivision();
         $tier1    = Award::factory()->create(['division_id' => $division->id]);
@@ -275,7 +294,8 @@ class AwardTest extends TestCase
         $this->assertTrue($tier2->isPartOfTieredGroup());
     }
 
-    public function test_is_part_of_tiered_group_returns_true_when_has_dependents()
+    #[Test]
+    public function is_part_of_tiered_group_returns_true_when_has_dependents()
     {
         $division = $this->createActiveDivision();
         $tier1    = Award::factory()->create(['division_id' => $division->id]);
@@ -287,7 +307,8 @@ class AwardTest extends TestCase
         $this->assertTrue($tier1->fresh()->isPartOfTieredGroup());
     }
 
-    public function test_is_part_of_tiered_group_returns_false_for_standalone_award()
+    #[Test]
+    public function is_part_of_tiered_group_returns_false_for_standalone_award()
     {
         $division = $this->createActiveDivision();
         $award    = Award::factory()->create(['division_id' => $division->id]);
@@ -295,7 +316,8 @@ class AwardTest extends TestCase
         $this->assertFalse($award->isPartOfTieredGroup());
     }
 
-    public function test_get_prerequisite_chain_returns_all_prerequisites_in_order()
+    #[Test]
+    public function get_prerequisite_chain_returns_all_prerequisites_in_order()
     {
         $division = $this->createActiveDivision();
         $tier1    = Award::factory()->create(['division_id' => $division->id, 'name' => 'Tier 1']);
@@ -317,7 +339,8 @@ class AwardTest extends TestCase
         $this->assertEquals($tier1->id, $chain[1]->id);
     }
 
-    public function test_get_tiered_group_slug_returns_slug_from_base_tier_name()
+    #[Test]
+    public function get_tiered_group_slug_returns_slug_from_base_tier_name()
     {
         $division = $this->createActiveDivision();
         $tier1    = Award::factory()->create([
@@ -336,7 +359,8 @@ class AwardTest extends TestCase
         $this->assertEquals('aod-tenure', $tier2->getTieredGroupSlug());
     }
 
-    public function test_get_tiered_group_slug_returns_null_for_standalone_award()
+    #[Test]
+    public function get_tiered_group_slug_returns_null_for_standalone_award()
     {
         $division = $this->createActiveDivision();
         $award    = Award::factory()->create(['division_id' => $division->id]);
@@ -344,7 +368,8 @@ class AwardTest extends TestCase
         $this->assertNull($award->getTieredGroupSlug());
     }
 
-    public function test_tiered_award_cannot_be_repeated_even_if_marked_repeatable()
+    #[Test]
+    public function tiered_award_cannot_be_repeated_even_if_marked_repeatable()
     {
         $division = $this->createActiveDivision();
         $tier1    = Award::factory()->create([
@@ -371,7 +396,8 @@ class AwardTest extends TestCase
         $this->assertTrue($validator->fails());
     }
 
-    public function test_recipients_excludes_members_without_division()
+    #[Test]
+    public function recipients_excludes_members_without_division()
     {
         $division = $this->createActiveDivision();
         $award    = Award::factory()->create(['division_id' => $division->id]);
@@ -396,7 +422,8 @@ class AwardTest extends TestCase
         $this->assertEquals($memberWithDivision->id, $recipients->first()->member_id);
     }
 
-    public function test_recipients_count_excludes_members_without_division()
+    #[Test]
+    public function recipients_count_excludes_members_without_division()
     {
         $division = $this->createActiveDivision();
         $award    = Award::factory()->create(['division_id' => $division->id]);

--- a/tests/Unit/Models/DivisionTagTest.php
+++ b/tests/Unit/Models/DivisionTagTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit\Models;
 
 use App\Models\DivisionTag;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Traits\CreatesDivisions;
 use Tests\Traits\CreatesMembers;
@@ -14,14 +15,16 @@ class DivisionTagTest extends TestCase
     use CreatesMembers;
     use RefreshDatabase;
 
-    public function test_is_global_returns_true_for_null_division()
+    #[Test]
+    public function is_global_returns_true_for_null_division()
     {
         $tag = DivisionTag::factory()->global()->create();
 
         $this->assertTrue($tag->isGlobal());
     }
 
-    public function test_is_global_returns_false_for_division_tag()
+    #[Test]
+    public function is_global_returns_false_for_division_tag()
     {
         $division = $this->createActiveDivision();
         $tag      = DivisionTag::factory()->create(['division_id' => $division->id]);
@@ -29,7 +32,8 @@ class DivisionTagTest extends TestCase
         $this->assertFalse($tag->isGlobal());
     }
 
-    public function test_scope_global_returns_only_global_tags()
+    #[Test]
+    public function scope_global_returns_only_global_tags()
     {
         $division    = $this->createActiveDivision();
         $globalTag   = DivisionTag::factory()->global()->create();
@@ -41,7 +45,8 @@ class DivisionTagTest extends TestCase
         $this->assertFalse($results->contains($divisionTag));
     }
 
-    public function test_scope_by_division_returns_only_that_divisions_tags()
+    #[Test]
+    public function scope_by_division_returns_only_that_divisions_tags()
     {
         $division1 = $this->createActiveDivision();
         $division2 = $this->createActiveDivision();
@@ -55,7 +60,8 @@ class DivisionTagTest extends TestCase
         $this->assertFalse($results->contains($tag2));
     }
 
-    public function test_scope_for_division_includes_global_tags()
+    #[Test]
+    public function scope_for_division_includes_global_tags()
     {
         $division = $this->createActiveDivision();
 
@@ -68,7 +74,8 @@ class DivisionTagTest extends TestCase
         $this->assertTrue($results->contains($globalTag));
     }
 
-    public function test_scope_for_division_excludes_other_division_tags()
+    #[Test]
+    public function scope_for_division_excludes_other_division_tags()
     {
         $division1 = $this->createActiveDivision();
         $division2 = $this->createActiveDivision();
@@ -82,21 +89,24 @@ class DivisionTagTest extends TestCase
         $this->assertFalse($results->contains($tag2));
     }
 
-    public function test_is_visible_to_returns_true_for_public_tag_without_user()
+    #[Test]
+    public function is_visible_to_returns_true_for_public_tag_without_user()
     {
         $tag = DivisionTag::factory()->public()->create();
 
         $this->assertTrue($tag->isVisibleTo(null));
     }
 
-    public function test_is_visible_to_returns_false_for_officers_tag_without_user()
+    #[Test]
+    public function is_visible_to_returns_false_for_officers_tag_without_user()
     {
         $tag = DivisionTag::factory()->officersOnly()->create();
 
         $this->assertTrue($tag->isVisibleTo(null) === false);
     }
 
-    public function test_is_visible_to_returns_true_for_admin_on_any_tag()
+    #[Test]
+    public function is_visible_to_returns_true_for_admin_on_any_tag()
     {
         $admin = $this->createAdmin();
 
@@ -109,7 +119,8 @@ class DivisionTagTest extends TestCase
         $this->assertTrue($srLdrsTag->isVisibleTo($admin));
     }
 
-    public function test_is_visible_to_returns_true_for_sr_ldr_on_any_tag()
+    #[Test]
+    public function is_visible_to_returns_true_for_sr_ldr_on_any_tag()
     {
         $srLeader = $this->createSeniorLeader();
 
@@ -122,7 +133,8 @@ class DivisionTagTest extends TestCase
         $this->assertTrue($srLdrsTag->isVisibleTo($srLeader));
     }
 
-    public function test_is_visible_to_returns_correct_values_for_officer()
+    #[Test]
+    public function is_visible_to_returns_correct_values_for_officer()
     {
         $officer = $this->createOfficer();
 
@@ -135,7 +147,8 @@ class DivisionTagTest extends TestCase
         $this->assertFalse($srLdrsTag->isVisibleTo($officer));
     }
 
-    public function test_scope_visible_to_filters_correctly_for_null_user()
+    #[Test]
+    public function scope_visible_to_filters_correctly_for_null_user()
     {
         $publicTag   = DivisionTag::factory()->public()->create();
         $officersTag = DivisionTag::factory()->officersOnly()->create();
@@ -146,7 +159,8 @@ class DivisionTagTest extends TestCase
         $this->assertFalse($results->contains($officersTag));
     }
 
-    public function test_scope_visible_to_returns_all_for_admin()
+    #[Test]
+    public function scope_visible_to_returns_all_for_admin()
     {
         $admin = $this->createAdmin();
 
@@ -161,7 +175,8 @@ class DivisionTagTest extends TestCase
         $this->assertTrue($results->contains($srLdrsTag));
     }
 
-    public function test_scope_visible_to_filters_correctly_for_officer()
+    #[Test]
+    public function scope_visible_to_filters_correctly_for_officer()
     {
         $officer = $this->createOfficer();
 
@@ -176,7 +191,8 @@ class DivisionTagTest extends TestCase
         $this->assertFalse($results->contains($srLdrsTag));
     }
 
-    public function test_scope_assignable_by_returns_none_for_null_user()
+    #[Test]
+    public function scope_assignable_by_returns_none_for_null_user()
     {
         $publicTag = DivisionTag::factory()->public()->create();
 
@@ -185,7 +201,8 @@ class DivisionTagTest extends TestCase
         $this->assertFalse($results->contains($publicTag));
     }
 
-    public function test_scope_assignable_by_returns_all_for_admin()
+    #[Test]
+    public function scope_assignable_by_returns_all_for_admin()
     {
         $admin = $this->createAdmin();
 
@@ -198,7 +215,8 @@ class DivisionTagTest extends TestCase
         $this->assertTrue($results->contains($srLdrsTag));
     }
 
-    public function test_scope_assignable_by_filters_correctly_for_officer()
+    #[Test]
+    public function scope_assignable_by_filters_correctly_for_officer()
     {
         $officer = $this->createOfficer();
 
@@ -213,7 +231,8 @@ class DivisionTagTest extends TestCase
         $this->assertFalse($results->contains($srLdrsTag));
     }
 
-    public function test_members_relationship_returns_tagged_members()
+    #[Test]
+    public function members_relationship_returns_tagged_members()
     {
         $division = $this->createActiveDivision();
         $tag      = DivisionTag::factory()->create(['division_id' => $division->id]);

--- a/tests/Unit/Models/DivisionTest.php
+++ b/tests/Unit/Models/DivisionTest.php
@@ -7,6 +7,7 @@ use App\Enums\Rank;
 use App\Models\Division;
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Traits\CreatesDivisions;
 use Tests\Traits\CreatesMembers;
@@ -17,14 +18,16 @@ class DivisionTest extends TestCase
     use CreatesMembers;
     use RefreshDatabase;
 
-    public function test_it_has_a_lowercase_abbreviation()
+    #[Test]
+    public function it_has_a_lowercase_abbreviation()
     {
         $division = Division::factory(['abbreviation' => 'UPPERCASE'])->make();
 
         $this->assertSame($division->abbreviation, 'uppercase');
     }
 
-    public function test_creating_division_sets_default_settings()
+    #[Test]
+    public function creating_division_sets_default_settings()
     {
         $division = Division::factory()->create(['name' => 'Test Division']);
 
@@ -33,14 +36,16 @@ class DivisionTest extends TestCase
         $this->assertArrayHasKey('chat_alerts', $division->settings);
     }
 
-    public function test_creating_division_generates_slug_from_name()
+    #[Test]
+    public function creating_division_generates_slug_from_name()
     {
         $division = Division::factory()->create(['name' => 'Test Division Name']);
 
         $this->assertEquals('test-division-name', $division->slug);
     }
 
-    public function test_scope_active_returns_only_active_divisions()
+    #[Test]
+    public function scope_active_returns_only_active_divisions()
     {
         $activeDivision   = $this->createActiveDivision();
         $inactiveDivision = $this->createInactiveDivision();
@@ -51,7 +56,8 @@ class DivisionTest extends TestCase
         $this->assertFalse($results->contains($inactiveDivision));
     }
 
-    public function test_scope_without_floaters_excludes_floater_division()
+    #[Test]
+    public function scope_without_floaters_excludes_floater_division()
     {
         $regularDivision = Division::factory()->create(['name' => 'Regular', 'slug' => 'regular']);
         $floaterDivision = Division::factory()->create(['name' => 'Floater', 'slug' => 'floater']);
@@ -62,7 +68,8 @@ class DivisionTest extends TestCase
         $this->assertFalse($results->contains($floaterDivision));
     }
 
-    public function test_scope_shutting_down_excludes_shutdown_divisions_by_default()
+    #[Test]
+    public function scope_shutting_down_excludes_shutdown_divisions_by_default()
     {
         $activeDivision       = Division::factory()->create(['shutdown_at' => null]);
         $shuttingDownDivision = Division::factory()->create(['shutdown_at' => now()]);
@@ -73,7 +80,8 @@ class DivisionTest extends TestCase
         $this->assertFalse($results->contains($shuttingDownDivision));
     }
 
-    public function test_scope_shutting_down_includes_shutdown_divisions_when_flag_set()
+    #[Test]
+    public function scope_shutting_down_includes_shutdown_divisions_when_flag_set()
     {
         $activeDivision       = Division::factory()->create(['shutdown_at' => null]);
         $shuttingDownDivision = Division::factory()->create(['shutdown_at' => now()]);
@@ -84,7 +92,8 @@ class DivisionTest extends TestCase
         $this->assertTrue($results->contains($shuttingDownDivision));
     }
 
-    public function test_members_active_since_days_ago_filters_correctly()
+    #[Test]
+    public function members_active_since_days_ago_filters_correctly()
     {
         $division = $this->createActiveDivision();
 
@@ -104,7 +113,8 @@ class DivisionTest extends TestCase
         $this->assertFalse($results->contains($inactiveOld));
     }
 
-    public function test_members_active_on_discord_since_days_ago_filters_correctly()
+    #[Test]
+    public function members_active_on_discord_since_days_ago_filters_correctly()
     {
         $division = $this->createActiveDivision();
 
@@ -124,7 +134,8 @@ class DivisionTest extends TestCase
         $this->assertFalse($results->contains($inactiveOld));
     }
 
-    public function test_sergeants_returns_members_with_rank_sergeant_or_higher()
+    #[Test]
+    public function sergeants_returns_members_with_rank_sergeant_or_higher()
     {
         $division = $this->createActiveDivision();
 
@@ -144,7 +155,8 @@ class DivisionTest extends TestCase
         $this->assertFalse($results->contains($corporal));
     }
 
-    public function test_leaders_returns_co_and_xo()
+    #[Test]
+    public function leaders_returns_co_and_xo()
     {
         $division = $this->createActiveDivision();
 
@@ -159,7 +171,8 @@ class DivisionTest extends TestCase
         $this->assertFalse($results->contains($regularMember));
     }
 
-    public function test_unassigned_returns_members_without_platoon()
+    #[Test]
+    public function unassigned_returns_members_without_platoon()
     {
         $division = $this->createActiveDivision();
         $platoon  = $this->createPlatoon($division);
@@ -182,7 +195,8 @@ class DivisionTest extends TestCase
         $this->assertFalse($results->contains($assigned));
     }
 
-    public function test_is_active_returns_correct_value()
+    #[Test]
+    public function is_active_returns_correct_value()
     {
         $activeDivision   = $this->createActiveDivision();
         $inactiveDivision = $this->createInactiveDivision();
@@ -191,7 +205,8 @@ class DivisionTest extends TestCase
         $this->assertFalse($inactiveDivision->isActive());
     }
 
-    public function test_is_shutdown_returns_correct_value()
+    #[Test]
+    public function is_shutdown_returns_correct_value()
     {
         $normalDivision   = Division::factory()->create(['shutdown_at' => null]);
         $shutdownDivision = Division::factory()->create(['shutdown_at' => now()]);
@@ -200,7 +215,8 @@ class DivisionTest extends TestCase
         $this->assertTrue((bool) $shutdownDivision->isShutdown());
     }
 
-    public function test_locality_returns_correct_translation()
+    #[Test]
+    public function locality_returns_correct_translation()
     {
         $division           = $this->createActiveDivision();
         $division->settings = array_merge($division->defaultSettings, [
@@ -215,14 +231,16 @@ class DivisionTest extends TestCase
         $this->assertEquals('Company', $division->locality('platoon'));
     }
 
-    public function test_locality_returns_ucwords_for_missing_translation()
+    #[Test]
+    public function locality_returns_ucwords_for_missing_translation()
     {
         $division = $this->createActiveDivision();
 
         $this->assertEquals('Unknown Term', $division->locality('unknown term'));
     }
 
-    public function test_new_members_last_30_returns_recent_joins()
+    #[Test]
+    public function new_members_last_30_returns_recent_joins()
     {
         $division = $this->createActiveDivision();
 

--- a/tests/Unit/Models/LeaveTest.php
+++ b/tests/Unit/Models/LeaveTest.php
@@ -20,7 +20,7 @@ class LeaveTest extends TestCase
         $member = $this->createMember();
 
         $leave = Leave::factory()->expired()->create([
-            'member_id' => $member->clan_id,
+            'member_id' => $member->id,
         ]);
 
         $this->assertTrue($leave->expired);
@@ -31,7 +31,7 @@ class LeaveTest extends TestCase
         $member = $this->createMember();
 
         $leave = Leave::factory()->create([
-            'member_id' => $member->clan_id,
+            'member_id' => $member->id,
             'end_date'  => Carbon::now()->addDays(30),
         ]);
 
@@ -44,7 +44,7 @@ class LeaveTest extends TestCase
         $endDate = Carbon::parse('2025-06-15');
 
         $leave = Leave::factory()->create([
-            'member_id' => $member->clan_id,
+            'member_id' => $member->id,
             'end_date'  => $endDate,
         ]);
 
@@ -56,10 +56,10 @@ class LeaveTest extends TestCase
         $member = $this->createMember();
 
         $leave = Leave::factory()->create([
-            'member_id' => $member->clan_id,
+            'member_id' => $member->id,
         ]);
 
-        $this->assertEquals($member->clan_id, $leave->member->clan_id);
+        $this->assertEquals($member->id, $leave->member->id);
     }
 
     public function test_static_reasons_array_contains_expected_values()
@@ -76,7 +76,7 @@ class LeaveTest extends TestCase
         $member = $this->createMember();
 
         $leave = Leave::factory()->military()->create([
-            'member_id' => $member->clan_id,
+            'member_id' => $member->id,
         ]);
 
         $this->assertEquals('military', $leave->reason);
@@ -87,7 +87,7 @@ class LeaveTest extends TestCase
         $member = $this->createMember();
 
         $leave = Leave::factory()->medical()->create([
-            'member_id' => $member->clan_id,
+            'member_id' => $member->id,
         ]);
 
         $this->assertEquals('medical', $leave->reason);

--- a/tests/Unit/Models/LeaveTest.php
+++ b/tests/Unit/Models/LeaveTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Models;
 use App\Models\Leave;
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Traits\CreatesDivisions;
 use Tests\Traits\CreatesMembers;
@@ -15,7 +16,8 @@ class LeaveTest extends TestCase
     use CreatesMembers;
     use RefreshDatabase;
 
-    public function test_expired_attribute_returns_true_for_past_end_date()
+    #[Test]
+    public function expired_attribute_returns_true_for_past_end_date()
     {
         $member = $this->createMember();
 
@@ -26,7 +28,8 @@ class LeaveTest extends TestCase
         $this->assertTrue($leave->expired);
     }
 
-    public function test_expired_attribute_returns_false_for_future_end_date()
+    #[Test]
+    public function expired_attribute_returns_false_for_future_end_date()
     {
         $member = $this->createMember();
 
@@ -38,7 +41,8 @@ class LeaveTest extends TestCase
         $this->assertFalse($leave->expired);
     }
 
-    public function test_date_attribute_returns_formatted_end_date()
+    #[Test]
+    public function date_attribute_returns_formatted_end_date()
     {
         $member  = $this->createMember();
         $endDate = Carbon::parse('2025-06-15');
@@ -51,7 +55,8 @@ class LeaveTest extends TestCase
         $this->assertEquals('2025-06-15', $leave->date);
     }
 
-    public function test_member_relationship_returns_correct_member()
+    #[Test]
+    public function member_relationship_returns_correct_member()
     {
         $member = $this->createMember();
 
@@ -62,7 +67,8 @@ class LeaveTest extends TestCase
         $this->assertEquals($member->id, $leave->member->id);
     }
 
-    public function test_static_reasons_array_contains_expected_values()
+    #[Test]
+    public function static_reasons_array_contains_expected_values()
     {
         $expectedReasons = ['military', 'medical', 'education', 'travel', 'other'];
 
@@ -71,7 +77,8 @@ class LeaveTest extends TestCase
         }
     }
 
-    public function test_leave_factory_military_state()
+    #[Test]
+    public function leave_factory_military_state()
     {
         $member = $this->createMember();
 
@@ -82,7 +89,8 @@ class LeaveTest extends TestCase
         $this->assertEquals('military', $leave->reason);
     }
 
-    public function test_leave_factory_medical_state()
+    #[Test]
+    public function leave_factory_medical_state()
     {
         $member = $this->createMember();
 

--- a/tests/Unit/Models/MemberTest.php
+++ b/tests/Unit/Models/MemberTest.php
@@ -7,6 +7,7 @@ use App\Enums\Rank;
 use App\Models\DivisionTag;
 use App\Models\Member;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Traits\CreatesDivisions;
 use Tests\Traits\CreatesMembers;
@@ -17,7 +18,8 @@ class MemberTest extends TestCase
     use CreatesMembers;
     use RefreshDatabase;
 
-    public function test_is_squad_leader_returns_true_when_member_is_squad_leader()
+    #[Test]
+    public function is_squad_leader_returns_true_when_member_is_squad_leader()
     {
         $squad  = $this->createSquad();
         $member = $this->createSquadLeader($squad);
@@ -25,7 +27,8 @@ class MemberTest extends TestCase
         $this->assertTrue($member->isSquadLeader($squad));
     }
 
-    public function test_is_squad_leader_returns_false_when_member_is_not_squad_leader()
+    #[Test]
+    public function is_squad_leader_returns_false_when_member_is_not_squad_leader()
     {
         $squad  = $this->createSquad();
         $member = $this->createMember(['squad_id' => $squad->id]);
@@ -33,7 +36,8 @@ class MemberTest extends TestCase
         $this->assertFalse($member->isSquadLeader($squad));
     }
 
-    public function test_is_platoon_leader_returns_true_when_member_is_platoon_leader()
+    #[Test]
+    public function is_platoon_leader_returns_true_when_member_is_platoon_leader()
     {
         $platoon = $this->createPlatoon();
         $member  = $this->createPlatoonLeader($platoon);
@@ -41,7 +45,8 @@ class MemberTest extends TestCase
         $this->assertTrue($member->isPlatoonLeader($platoon));
     }
 
-    public function test_is_platoon_leader_returns_false_when_member_is_not_platoon_leader()
+    #[Test]
+    public function is_platoon_leader_returns_false_when_member_is_not_platoon_leader()
     {
         $platoon = $this->createPlatoon();
         $member  = $this->createMember(['platoon_id' => $platoon->id]);
@@ -49,7 +54,8 @@ class MemberTest extends TestCase
         $this->assertFalse($member->isPlatoonLeader($platoon));
     }
 
-    public function test_is_division_leader_returns_true_for_commanding_officer()
+    #[Test]
+    public function is_division_leader_returns_true_for_commanding_officer()
     {
         $division = $this->createActiveDivision();
         $member   = $this->createCommander($division);
@@ -57,7 +63,8 @@ class MemberTest extends TestCase
         $this->assertTrue($member->isDivisionLeader($division));
     }
 
-    public function test_is_division_leader_returns_true_for_executive_officer()
+    #[Test]
+    public function is_division_leader_returns_true_for_executive_officer()
     {
         $division = $this->createActiveDivision();
         $member   = $this->createExecutiveOfficer($division);
@@ -65,7 +72,8 @@ class MemberTest extends TestCase
         $this->assertTrue($member->isDivisionLeader($division));
     }
 
-    public function test_is_division_leader_returns_false_for_regular_member()
+    #[Test]
+    public function is_division_leader_returns_false_for_regular_member()
     {
         $division = $this->createActiveDivision();
         $member   = $this->createMember(['division_id' => $division->id]);
@@ -73,7 +81,8 @@ class MemberTest extends TestCase
         $this->assertFalse($member->isDivisionLeader($division));
     }
 
-    public function test_is_division_leader_returns_false_when_member_in_different_division()
+    #[Test]
+    public function is_division_leader_returns_false_when_member_in_different_division()
     {
         $division1 = $this->createActiveDivision();
         $division2 = $this->createActiveDivision();
@@ -82,7 +91,8 @@ class MemberTest extends TestCase
         $this->assertFalse($member->isDivisionLeader($division2));
     }
 
-    public function test_reset_clears_division_assignments()
+    #[Test]
+    public function reset_clears_division_assignments()
     {
         $division = $this->createDivisionWithFullStructure(1, 1, 1);
         $platoon  = $division->platoons->first();
@@ -106,7 +116,8 @@ class MemberTest extends TestCase
         $this->assertFalse($member->flagged_for_inactivity);
     }
 
-    public function test_reset_detaches_part_time_divisions()
+    #[Test]
+    public function reset_detaches_part_time_divisions()
     {
         $division         = $this->createActiveDivision();
         $partTimeDivision = $this->createActiveDivision();
@@ -122,7 +133,8 @@ class MemberTest extends TestCase
         $this->assertCount(0, $member->partTimeDivisions);
     }
 
-    public function test_reset_detaches_division_specific_tags()
+    #[Test]
+    public function reset_detaches_division_specific_tags()
     {
         $division = $this->createActiveDivision();
         $member   = $this->createMember(['division_id' => $division->id]);
@@ -142,7 +154,8 @@ class MemberTest extends TestCase
         $this->assertFalse($member->tags->contains($divisionTag));
     }
 
-    public function test_scope_unassigned_squad_leaders_returns_orphaned_leaders()
+    #[Test]
+    public function scope_unassigned_squad_leaders_returns_orphaned_leaders()
     {
         $division = $this->createActiveDivision();
         $squad    = $this->createSquad($this->createPlatoon($division));
@@ -160,7 +173,8 @@ class MemberTest extends TestCase
         $this->assertFalse($results->contains($assignedLeader));
     }
 
-    public function test_scope_unassigned_platoon_leaders_returns_orphaned_leaders()
+    #[Test]
+    public function scope_unassigned_platoon_leaders_returns_orphaned_leaders()
     {
         $division = $this->createActiveDivision();
         $platoon  = $this->createPlatoon($division);
@@ -178,7 +192,8 @@ class MemberTest extends TestCase
         $this->assertFalse($results->contains($assignedLeader));
     }
 
-    public function test_is_rank_with_single_rank_returns_correct_value()
+    #[Test]
+    public function is_rank_with_single_rank_returns_correct_value()
     {
         $member = $this->createMember(['rank' => Rank::SERGEANT]);
 
@@ -186,7 +201,8 @@ class MemberTest extends TestCase
         $this->assertFalse($member->isRank(Rank::CORPORAL));
     }
 
-    public function test_is_rank_with_array_returns_correct_value()
+    #[Test]
+    public function is_rank_with_array_returns_correct_value()
     {
         $member = $this->createMember(['rank' => Rank::SERGEANT]);
 
@@ -194,7 +210,8 @@ class MemberTest extends TestCase
         $this->assertFalse($member->isRank([Rank::CORPORAL, Rank::SPECIALIST]));
     }
 
-    public function test_bot_response_formats_correctly()
+    #[Test]
+    public function bot_response_formats_correctly()
     {
         $division = $this->createActiveDivision(['name' => 'Test Division']);
         $member   = $this->createMember([
@@ -211,7 +228,8 @@ class MemberTest extends TestCase
         $this->assertStringContainsString('testuser#1234', $response['value']);
     }
 
-    public function test_bot_response_shows_ex_aod_for_member_without_division()
+    #[Test]
+    public function bot_response_shows_ex_aod_for_member_without_division()
     {
         $member = $this->createMember(['division_id' => 0]);
         $member->load('division');
@@ -221,7 +239,8 @@ class MemberTest extends TestCase
         $this->assertStringContainsString('Ex-AOD', $response['name']);
     }
 
-    public function test_get_discord_url_returns_url_when_discord_id_set()
+    #[Test]
+    public function get_discord_url_returns_url_when_discord_id_set()
     {
         $member = $this->createMember(['discord_id' => '123456789']);
 
@@ -230,7 +249,8 @@ class MemberTest extends TestCase
         $this->assertEquals('https://discordapp.com/users/123456789', $url);
     }
 
-    public function test_get_discord_url_returns_false_when_no_discord_id()
+    #[Test]
+    public function get_discord_url_returns_false_when_no_discord_id()
     {
         $member = $this->createMember(['discord_id' => null]);
 

--- a/tests/Unit/Models/RankActionTest.php
+++ b/tests/Unit/Models/RankActionTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Models;
 use App\Enums\Rank;
 use App\Models\RankAction;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Traits\CreatesDivisions;
 use Tests\Traits\CreatesMembers;
@@ -15,7 +16,8 @@ class RankActionTest extends TestCase
     use CreatesMembers;
     use RefreshDatabase;
 
-    public function test_approve_sets_approved_at_and_approver_id()
+    #[Test]
+    public function approve_sets_approved_at_and_approver_id()
     {
         $admin = $this->createAdmin();
         $this->actingAs($admin);
@@ -34,7 +36,8 @@ class RankActionTest extends TestCase
         $this->assertEquals($admin->member_id, $rankAction->approver_id);
     }
 
-    public function test_accept_sets_accepted_at()
+    #[Test]
+    public function accept_sets_accepted_at()
     {
         $member     = $this->createMember();
         $rankAction = RankAction::factory()->create([
@@ -46,7 +49,8 @@ class RankActionTest extends TestCase
         $this->assertNotNull($rankAction->accepted_at);
     }
 
-    public function test_decline_sets_declined_at()
+    #[Test]
+    public function decline_sets_declined_at()
     {
         $member     = $this->createMember();
         $rankAction = RankAction::factory()->create([
@@ -58,7 +62,8 @@ class RankActionTest extends TestCase
         $this->assertNotNull($rankAction->declined_at);
     }
 
-    public function test_deny_sets_denied_at_and_reason()
+    #[Test]
+    public function deny_sets_denied_at_and_reason()
     {
         $member     = $this->createMember();
         $rankAction = RankAction::factory()->create([
@@ -71,7 +76,8 @@ class RankActionTest extends TestCase
         $this->assertEquals('Not eligible for promotion', $rankAction->deny_reason);
     }
 
-    public function test_award_sets_awarded_at()
+    #[Test]
+    public function award_sets_awarded_at()
     {
         $member     = $this->createMember();
         $rankAction = RankAction::factory()->create([
@@ -83,7 +89,8 @@ class RankActionTest extends TestCase
         $this->assertNotNull($rankAction->awarded_at);
     }
 
-    public function test_approve_and_accept_sets_all_timestamps()
+    #[Test]
+    public function approve_and_accept_sets_all_timestamps()
     {
         $member     = $this->createMember();
         $rankAction = RankAction::factory()->create([
@@ -97,7 +104,8 @@ class RankActionTest extends TestCase
         $this->assertNotNull($rankAction->awarded_at);
     }
 
-    public function test_is_approved_returns_truthy_when_approved()
+    #[Test]
+    public function is_approved_returns_truthy_when_approved()
     {
         $member     = $this->createMember();
         $rankAction = RankAction::factory()->approved()->create([
@@ -107,7 +115,8 @@ class RankActionTest extends TestCase
         $this->assertTrue((bool) $rankAction->isApproved());
     }
 
-    public function test_is_approved_returns_falsy_when_not_approved()
+    #[Test]
+    public function is_approved_returns_falsy_when_not_approved()
     {
         $member     = $this->createMember();
         $rankAction = RankAction::factory()->pending()->create([
@@ -117,7 +126,8 @@ class RankActionTest extends TestCase
         $this->assertFalse((bool) $rankAction->isApproved());
     }
 
-    public function test_actionable_returns_true_when_pending()
+    #[Test]
+    public function actionable_returns_true_when_pending()
     {
         $member     = $this->createMember();
         $rankAction = RankAction::factory()->pending()->create([
@@ -127,7 +137,8 @@ class RankActionTest extends TestCase
         $this->assertTrue($rankAction->actionable());
     }
 
-    public function test_actionable_returns_false_when_approved()
+    #[Test]
+    public function actionable_returns_false_when_approved()
     {
         $member     = $this->createMember();
         $rankAction = RankAction::factory()->approved()->create([
@@ -137,7 +148,8 @@ class RankActionTest extends TestCase
         $this->assertFalse($rankAction->actionable());
     }
 
-    public function test_actionable_returns_false_when_denied()
+    #[Test]
+    public function actionable_returns_false_when_denied()
     {
         $member     = $this->createMember();
         $rankAction = RankAction::factory()->denied()->create([
@@ -147,7 +159,8 @@ class RankActionTest extends TestCase
         $this->assertFalse($rankAction->actionable());
     }
 
-    public function test_resolved_by_recipient_returns_true_when_accepted()
+    #[Test]
+    public function resolved_by_recipient_returns_true_when_accepted()
     {
         $member     = $this->createMember();
         $rankAction = RankAction::factory()->accepted()->create([
@@ -157,7 +170,8 @@ class RankActionTest extends TestCase
         $this->assertTrue($rankAction->resolvedByRecipient());
     }
 
-    public function test_resolved_by_recipient_returns_true_when_declined()
+    #[Test]
+    public function resolved_by_recipient_returns_true_when_declined()
     {
         $member     = $this->createMember();
         $rankAction = RankAction::factory()->declined()->create([
@@ -167,7 +181,8 @@ class RankActionTest extends TestCase
         $this->assertTrue($rankAction->resolvedByRecipient());
     }
 
-    public function test_resolved_by_recipient_returns_false_when_pending()
+    #[Test]
+    public function resolved_by_recipient_returns_false_when_pending()
     {
         $member     = $this->createMember();
         $rankAction = RankAction::factory()->approved()->create([
@@ -179,7 +194,8 @@ class RankActionTest extends TestCase
         $this->assertFalse($rankAction->resolvedByRecipient());
     }
 
-    public function test_scope_pending_returns_unapproved_actions()
+    #[Test]
+    public function scope_pending_returns_unapproved_actions()
     {
         $member = $this->createMember();
 
@@ -192,7 +208,8 @@ class RankActionTest extends TestCase
         $this->assertFalse($results->contains($approved));
     }
 
-    public function test_scope_pending_returns_approved_but_not_accepted()
+    #[Test]
+    public function scope_pending_returns_approved_but_not_accepted()
     {
         $member = $this->createMember();
 
@@ -207,7 +224,8 @@ class RankActionTest extends TestCase
         $this->assertTrue($results->contains($approvedNotAccepted));
     }
 
-    public function test_scope_approved_and_accepted_returns_complete_actions()
+    #[Test]
+    public function scope_approved_and_accepted_returns_complete_actions()
     {
         $member = $this->createMember();
 
@@ -225,7 +243,8 @@ class RankActionTest extends TestCase
         $this->assertFalse($results->contains($pending));
     }
 
-    public function test_scope_for_user_filters_by_division_for_non_admin()
+    #[Test]
+    public function scope_for_user_filters_by_division_for_non_admin()
     {
         $division      = $this->createActiveDivision();
         $otherDivision = $this->createActiveDivision();

--- a/tests/Unit/Models/TicketTest.php
+++ b/tests/Unit/Models/TicketTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Models;
 use App\Models\Ticket;
 use App\Models\TicketType;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Traits\CreatesMembers;
 
@@ -13,7 +14,8 @@ class TicketTest extends TestCase
     use CreatesMembers;
     use RefreshDatabase;
 
-    public function test_scope_new_returns_only_new_tickets()
+    #[Test]
+    public function scope_new_returns_only_new_tickets()
     {
         $user       = $this->createMemberWithUser();
         $ticketType = TicketType::factory()->create();
@@ -36,7 +38,8 @@ class TicketTest extends TestCase
         $this->assertFalse($results->contains($assignedTicket));
     }
 
-    public function test_scope_assigned_returns_only_assigned_tickets()
+    #[Test]
+    public function scope_assigned_returns_only_assigned_tickets()
     {
         $user       = $this->createMemberWithUser();
         $ticketType = TicketType::factory()->create();
@@ -59,7 +62,8 @@ class TicketTest extends TestCase
         $this->assertTrue($results->contains($assignedTicket));
     }
 
-    public function test_scope_resolved_returns_only_resolved_tickets()
+    #[Test]
+    public function scope_resolved_returns_only_resolved_tickets()
     {
         $user       = $this->createMemberWithUser();
         $ticketType = TicketType::factory()->create();
@@ -82,7 +86,8 @@ class TicketTest extends TestCase
         $this->assertTrue($results->contains($resolvedTicket));
     }
 
-    public function test_state_color_attribute_returns_correct_color()
+    #[Test]
+    public function state_color_attribute_returns_correct_color()
     {
         $user       = $this->createMemberWithUser();
         $ticketType = TicketType::factory()->create();
@@ -103,7 +108,8 @@ class TicketTest extends TestCase
         $this->assertEquals('accent', $assignedTicket->stateColor);
     }
 
-    public function test_own_to_assigns_owner_and_changes_state()
+    #[Test]
+    public function own_to_assigns_owner_and_changes_state()
     {
         $caller     = $this->createMemberWithUser();
         $owner      = $this->createMemberWithUser();
@@ -124,7 +130,8 @@ class TicketTest extends TestCase
         $this->assertEquals('assigned', $ticket->state);
     }
 
-    public function test_resolve_sets_state_and_timestamps()
+    #[Test]
+    public function resolve_sets_state_and_timestamps()
     {
         $user       = $this->createMemberWithUser();
         $ticketType = TicketType::factory()->create();
@@ -145,7 +152,8 @@ class TicketTest extends TestCase
         $this->assertEquals($user->id, $ticket->owner_id);
     }
 
-    public function test_reopen_clears_resolved_at_and_sets_state()
+    #[Test]
+    public function reopen_clears_resolved_at_and_sets_state()
     {
         $user       = $this->createMemberWithUser();
         $ticketType = TicketType::factory()->create();
@@ -166,7 +174,8 @@ class TicketTest extends TestCase
         $this->assertNull($ticket->resolved_at);
     }
 
-    public function test_reject_sets_state_and_timestamps()
+    #[Test]
+    public function reject_sets_state_and_timestamps()
     {
         $user       = $this->createMemberWithUser();
         $ticketType = TicketType::factory()->create();
@@ -186,7 +195,8 @@ class TicketTest extends TestCase
         $this->assertNotNull($ticket->resolved_at);
     }
 
-    public function test_is_resolved_returns_correct_value()
+    #[Test]
+    public function is_resolved_returns_correct_value()
     {
         $user       = $this->createMemberWithUser();
         $ticketType = TicketType::factory()->create();
@@ -207,7 +217,8 @@ class TicketTest extends TestCase
         $this->assertTrue((bool) $resolvedTicket->isResolved());
     }
 
-    public function test_say_creates_comment()
+    #[Test]
+    public function say_creates_comment()
     {
         $user       = $this->createMemberWithUser();
         $ticketType = TicketType::factory()->create();
@@ -225,7 +236,8 @@ class TicketTest extends TestCase
         $this->assertEquals('Test comment', $ticket->comments->first()->body);
     }
 
-    public function test_has_external_message_id_returns_correct_value()
+    #[Test]
+    public function has_external_message_id_returns_correct_value()
     {
         $user       = $this->createMemberWithUser();
         $ticketType = TicketType::factory()->create();
@@ -246,7 +258,8 @@ class TicketTest extends TestCase
         $this->assertFalse($ticketWithoutId->hasExternalMessageId());
     }
 
-    public function test_type_relationship_returns_correct_ticket_type()
+    #[Test]
+    public function type_relationship_returns_correct_ticket_type()
     {
         $user       = $this->createMemberWithUser();
         $ticketType = TicketType::factory()->create(['name' => 'Test Type']);
@@ -259,7 +272,8 @@ class TicketTest extends TestCase
         $this->assertEquals('Test Type', $ticket->type->name);
     }
 
-    public function test_caller_relationship_returns_correct_user()
+    #[Test]
+    public function caller_relationship_returns_correct_user()
     {
         $user       = $this->createMemberWithUser();
         $ticketType = TicketType::factory()->create();

--- a/tests/Unit/Models/TransferTest.php
+++ b/tests/Unit/Models/TransferTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Models;
 use App\Enums\Position;
 use App\Models\Transfer;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Traits\CreatesDivisions;
 use Tests\Traits\CreatesMembers;
@@ -15,7 +16,8 @@ class TransferTest extends TestCase
     use CreatesMembers;
     use RefreshDatabase;
 
-    public function test_approve_sets_approved_at()
+    #[Test]
+    public function approve_sets_approved_at()
     {
         $sourceDivision = $this->createActiveDivision();
         $targetDivision = $this->createActiveDivision();
@@ -35,7 +37,8 @@ class TransferTest extends TestCase
         $this->assertNotNull($transfer->approved_at);
     }
 
-    public function test_approve_sets_approved_by_to_authenticated_user()
+    #[Test]
+    public function approve_sets_approved_by_to_authenticated_user()
     {
         $approver = $this->createSeniorLeader();
         $this->actingAs($approver);
@@ -58,7 +61,8 @@ class TransferTest extends TestCase
         $this->assertEquals($approver->id, $transfer->approved_by);
     }
 
-    public function test_approver_relationship_returns_user_who_approved()
+    #[Test]
+    public function approver_relationship_returns_user_who_approved()
     {
         $approver = $this->createSeniorLeader();
         $this->actingAs($approver);
@@ -77,7 +81,8 @@ class TransferTest extends TestCase
         $this->assertTrue($transfer->approver->is($approver));
     }
 
-    public function test_approve_transfers_member_to_new_division()
+    #[Test]
+    public function approve_transfers_member_to_new_division()
     {
         $sourceDivision = $this->createActiveDivision();
         $targetDivision = $this->createActiveDivision();
@@ -106,7 +111,8 @@ class TransferTest extends TestCase
         $this->assertEquals(Position::MEMBER, $member->position);
     }
 
-    public function test_approve_removes_squad_leader_assignment()
+    #[Test]
+    public function approve_removes_squad_leader_assignment()
     {
         $sourceDivision = $this->createActiveDivision();
         $targetDivision = $this->createActiveDivision();
@@ -129,7 +135,8 @@ class TransferTest extends TestCase
         $this->assertEquals(0, $squad->leader_id);
     }
 
-    public function test_approve_removes_platoon_leader_assignment()
+    #[Test]
+    public function approve_removes_platoon_leader_assignment()
     {
         $sourceDivision = $this->createActiveDivision();
         $targetDivision = $this->createActiveDivision();
@@ -150,7 +157,8 @@ class TransferTest extends TestCase
         $this->assertEquals(0, $platoon->leader_id);
     }
 
-    public function test_scope_pending_returns_unapproved_transfers()
+    #[Test]
+    public function scope_pending_returns_unapproved_transfers()
     {
         $division = $this->createActiveDivision();
         $member   = $this->createMember();
@@ -171,7 +179,8 @@ class TransferTest extends TestCase
         $this->assertFalse($results->contains($approved));
     }
 
-    public function test_member_relationship_returns_correct_member()
+    #[Test]
+    public function member_relationship_returns_correct_member()
     {
         $member   = $this->createMember();
         $division = $this->createActiveDivision();
@@ -184,7 +193,8 @@ class TransferTest extends TestCase
         $this->assertTrue($transfer->member->is($member));
     }
 
-    public function test_division_relationship_returns_target_division()
+    #[Test]
+    public function division_relationship_returns_target_division()
     {
         $member   = $this->createMember();
         $division = $this->createActiveDivision();
@@ -197,7 +207,8 @@ class TransferTest extends TestCase
         $this->assertTrue($transfer->division->is($division));
     }
 
-    public function test_approve_preserves_clan_admin_position()
+    #[Test]
+    public function approve_preserves_clan_admin_position()
     {
         $sourceDivision = $this->createActiveDivision();
         $targetDivision = $this->createActiveDivision();

--- a/tests/Unit/Models/UserTest.php
+++ b/tests/Unit/Models/UserTest.php
@@ -8,6 +8,7 @@ use App\Enums\Role;
 use App\Models\Member;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Traits\CreatesDivisions;
 use Tests\Traits\CreatesMembers;
@@ -18,7 +19,8 @@ class UserTest extends TestCase
     use CreatesMembers;
     use RefreshDatabase;
 
-    public function test_creating_user_sets_default_settings()
+    #[Test]
+    public function creating_user_sets_default_settings()
     {
         $user = User::factory()->create();
 
@@ -27,7 +29,8 @@ class UserTest extends TestCase
         $this->assertArrayHasKey('ticket_notifications', $user->settings);
     }
 
-    public function test_settings_accessor_merges_with_defaults()
+    #[Test]
+    public function settings_accessor_merges_with_defaults()
     {
         $user = User::factory()->create();
         $user->forceFill(['settings' => ['custom_key' => 'value']])->save();
@@ -38,14 +41,16 @@ class UserTest extends TestCase
         $this->assertEquals('value', $user->settings['custom_key']);
     }
 
-    public function test_name_accessor_capitalizes_first_letter()
+    #[Test]
+    public function name_accessor_capitalizes_first_letter()
     {
         $user = User::factory()->create(['name' => 'testuser']);
 
         $this->assertEquals('Testuser', $user->name);
     }
 
-    public function test_is_role_with_string_returns_correct_value()
+    #[Test]
+    public function is_role_with_string_returns_correct_value()
     {
         $adminUser   = $this->createAdmin();
         $officerUser = $this->createOfficer();
@@ -55,7 +60,8 @@ class UserTest extends TestCase
         $this->assertTrue($officerUser->isRole('officer'));
     }
 
-    public function test_is_role_with_array_returns_correct_value()
+    #[Test]
+    public function is_role_with_array_returns_correct_value()
     {
         $adminUser = $this->createAdmin();
 
@@ -63,7 +69,8 @@ class UserTest extends TestCase
         $this->assertFalse($adminUser->isRole(['officer', 'member']));
     }
 
-    public function test_is_role_with_enum_returns_correct_value()
+    #[Test]
+    public function is_role_with_enum_returns_correct_value()
     {
         $adminUser   = $this->createAdmin();
         $officerUser = $this->createOfficer();
@@ -73,7 +80,8 @@ class UserTest extends TestCase
         $this->assertTrue($officerUser->isRole(Role::OFFICER));
     }
 
-    public function test_get_role_returns_role_enum()
+    #[Test]
+    public function get_role_returns_role_enum()
     {
         $adminUser   = $this->createAdmin();
         $officerUser = $this->createOfficer();
@@ -82,7 +90,8 @@ class UserTest extends TestCase
         $this->assertEquals(Role::OFFICER, $officerUser->getRole());
     }
 
-    public function test_is_member_returns_true_for_member_position()
+    #[Test]
+    public function is_member_returns_true_for_member_position()
     {
         $division = $this->createActiveDivision();
         $user     = $this->createMemberWithUser([
@@ -93,7 +102,8 @@ class UserTest extends TestCase
         $this->assertTrue($user->isMember());
     }
 
-    public function test_is_member_returns_false_for_leader_position()
+    #[Test]
+    public function is_member_returns_false_for_leader_position()
     {
         $division = $this->createActiveDivision();
         $user     = $this->createMemberWithUser([
@@ -104,7 +114,8 @@ class UserTest extends TestCase
         $this->assertFalse($user->isMember());
     }
 
-    public function test_is_squad_leader_returns_correct_value()
+    #[Test]
+    public function is_squad_leader_returns_correct_value()
     {
         $division        = $this->createActiveDivision();
         $squadLeaderUser = $this->createMemberWithUser([
@@ -120,7 +131,8 @@ class UserTest extends TestCase
         $this->assertFalse($memberUser->isSquadLeader());
     }
 
-    public function test_is_platoon_leader_returns_correct_value()
+    #[Test]
+    public function is_platoon_leader_returns_correct_value()
     {
         $division          = $this->createActiveDivision();
         $platoonLeaderUser = $this->createMemberWithUser([
@@ -136,7 +148,8 @@ class UserTest extends TestCase
         $this->assertFalse($memberUser->isPlatoonLeader());
     }
 
-    public function test_is_division_leader_returns_true_for_co_or_xo()
+    #[Test]
+    public function is_division_leader_returns_true_for_co_or_xo()
     {
         $division = $this->createActiveDivision();
         $coUser   = $this->createMemberWithUser([
@@ -152,7 +165,8 @@ class UserTest extends TestCase
         $this->assertTrue($xoUser->isDivisionLeader());
     }
 
-    public function test_is_division_leader_returns_false_for_other_positions()
+    #[Test]
+    public function is_division_leader_returns_false_for_other_positions()
     {
         $division   = $this->createActiveDivision();
         $memberUser = $this->createMemberWithUser([
@@ -163,7 +177,8 @@ class UserTest extends TestCase
         $this->assertFalse($memberUser->isDivisionLeader());
     }
 
-    public function test_is_developer_returns_correct_value()
+    #[Test]
+    public function is_developer_returns_correct_value()
     {
         $adminUser   = $this->createAdmin();
         $regularUser = $this->createMemberWithUser([], ['developer' => false]);
@@ -172,7 +187,8 @@ class UserTest extends TestCase
         $this->assertFalse($regularUser->isDeveloper());
     }
 
-    public function test_can_remove_users_returns_true_for_sergeant_or_higher()
+    #[Test]
+    public function can_remove_users_returns_true_for_sergeant_or_higher()
     {
         $division     = $this->createActiveDivision();
         $sergeantUser = $this->createMemberWithUser([
@@ -188,7 +204,8 @@ class UserTest extends TestCase
         $this->assertFalse($corporalUser->canRemoveUsers());
     }
 
-    public function test_assign_role_with_role_enum()
+    #[Test]
+    public function assign_role_with_role_enum()
     {
         $user = User::factory()->create(['role' => Role::MEMBER]);
 
@@ -198,7 +215,8 @@ class UserTest extends TestCase
         $this->assertEquals(Role::ADMIN, $user->role);
     }
 
-    public function test_assign_role_with_string()
+    #[Test]
+    public function assign_role_with_string()
     {
         $user = User::factory()->create(['role' => Role::MEMBER]);
 
@@ -208,7 +226,8 @@ class UserTest extends TestCase
         $this->assertEquals(Role::ADMIN, $user->getRole());
     }
 
-    public function test_assign_role_with_integer()
+    #[Test]
+    public function assign_role_with_integer()
     {
         $user = User::factory()->create(['role' => Role::MEMBER]);
 
@@ -218,7 +237,8 @@ class UserTest extends TestCase
         $this->assertEquals(Role::ADMIN, $user->role);
     }
 
-    public function test_scope_admins_returns_only_admin_users()
+    #[Test]
+    public function scope_admins_returns_only_admin_users()
     {
         $adminUser   = $this->createAdmin();
         $regularUser = $this->createMemberWithUser();
@@ -229,7 +249,8 @@ class UserTest extends TestCase
         $this->assertFalse($results->contains($regularUser));
     }
 
-    public function test_find_or_create_for_member_creates_new_user()
+    #[Test]
+    public function find_or_create_for_member_creates_new_user()
     {
         $member = Member::factory()->create();
 
@@ -241,7 +262,8 @@ class UserTest extends TestCase
         $this->assertEquals(Role::MEMBER, $user->role);
     }
 
-    public function test_find_or_create_for_member_returns_existing_user()
+    #[Test]
+    public function find_or_create_for_member_returns_existing_user()
     {
         $member       = Member::factory()->create();
         $existingUser = User::factory()->create([
@@ -254,7 +276,8 @@ class UserTest extends TestCase
         $this->assertEquals($existingUser->id, $user->id);
     }
 
-    public function test_find_or_create_for_member_updates_email_if_changed_and_available()
+    #[Test]
+    public function find_or_create_for_member_updates_email_if_changed_and_available()
     {
         $member       = Member::factory()->create();
         $existingUser = User::factory()->create([
@@ -267,7 +290,8 @@ class UserTest extends TestCase
         $this->assertEquals('new@example.com', $user->fresh()->email);
     }
 
-    public function test_find_or_create_for_member_does_not_update_email_if_taken()
+    #[Test]
+    public function find_or_create_for_member_does_not_update_email_if_taken()
     {
         User::factory()->create(['email' => 'taken@example.com']);
 
@@ -282,7 +306,8 @@ class UserTest extends TestCase
         $this->assertEquals('original@example.com', $user->fresh()->email);
     }
 
-    public function test_find_or_create_for_member_generates_placeholder_email_when_null()
+    #[Test]
+    public function find_or_create_for_member_generates_placeholder_email_when_null()
     {
         $member = Member::factory()->create();
 
@@ -291,7 +316,8 @@ class UserTest extends TestCase
         $this->assertStringContainsString('@placeholder.local', $user->email);
     }
 
-    public function test_find_or_create_for_member_generates_placeholder_email_when_duplicate()
+    #[Test]
+    public function find_or_create_for_member_generates_placeholder_email_when_duplicate()
     {
         User::factory()->create(['email' => 'duplicate@example.com']);
         $member = Member::factory()->create();
@@ -301,7 +327,8 @@ class UserTest extends TestCase
         $this->assertStringContainsString('@placeholder.local', $user->email);
     }
 
-    public function test_find_or_create_for_member_does_not_update_email_when_null()
+    #[Test]
+    public function find_or_create_for_member_does_not_update_email_when_null()
     {
         $member       = Member::factory()->create();
         $existingUser = User::factory()->create([

--- a/tests/Unit/Policies/DivisionTagPolicyTest.php
+++ b/tests/Unit/Policies/DivisionTagPolicyTest.php
@@ -7,6 +7,7 @@ use App\Enums\Role;
 use App\Models\DivisionTag;
 use App\Policies\DivisionTagPolicy;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Traits\CreatesDivisions;
 use Tests\Traits\CreatesMembers;
@@ -25,14 +26,16 @@ class DivisionTagPolicyTest extends TestCase
         $this->policy = new DivisionTagPolicy;
     }
 
-    public function test_admin_bypasses_all_checks()
+    #[Test]
+    public function admin_bypasses_all_checks()
     {
         $admin = $this->createAdmin();
 
         $this->assertTrue($this->policy->before($admin));
     }
 
-    public function test_regular_user_does_not_bypass_checks()
+    #[Test]
+    public function regular_user_does_not_bypass_checks()
     {
         $division = $this->createActiveDivision();
         $user     = $this->createMemberWithUser(['division_id' => $division->id]);
@@ -40,7 +43,8 @@ class DivisionTagPolicyTest extends TestCase
         $this->assertNull($this->policy->before($user));
     }
 
-    public function test_view_any_returns_true()
+    #[Test]
+    public function view_any_returns_true()
     {
         $division = $this->createActiveDivision();
         $user     = $this->createMemberWithUser(['division_id' => $division->id]);
@@ -48,7 +52,8 @@ class DivisionTagPolicyTest extends TestCase
         $this->assertTrue($this->policy->viewAny($user));
     }
 
-    public function test_view_returns_true()
+    #[Test]
+    public function view_returns_true()
     {
         $division = $this->createActiveDivision();
         $user     = $this->createMemberWithUser(['division_id' => $division->id]);
@@ -57,21 +62,24 @@ class DivisionTagPolicyTest extends TestCase
         $this->assertTrue($this->policy->view($user, $tag));
     }
 
-    public function test_sr_ldr_can_create_tags()
+    #[Test]
+    public function sr_ldr_can_create_tags()
     {
         $srLdr = $this->createSeniorLeader();
 
         $this->assertTrue($this->policy->create($srLdr));
     }
 
-    public function test_officer_cannot_create_tags()
+    #[Test]
+    public function officer_cannot_create_tags()
     {
         $officer = $this->createOfficer();
 
         $this->assertFalse($this->policy->create($officer));
     }
 
-    public function test_member_cannot_create_tags()
+    #[Test]
+    public function member_cannot_create_tags()
     {
         $division = $this->createActiveDivision();
         $user     = $this->createMemberWithUser([
@@ -83,7 +91,8 @@ class DivisionTagPolicyTest extends TestCase
         $this->assertFalse($this->policy->create($user));
     }
 
-    public function test_sr_ldr_can_update_own_division_tag()
+    #[Test]
+    public function sr_ldr_can_update_own_division_tag()
     {
         $srLdr = $this->createSeniorLeader();
         $tag   = DivisionTag::factory()->create([
@@ -93,7 +102,8 @@ class DivisionTagPolicyTest extends TestCase
         $this->assertTrue($this->policy->update($srLdr, $tag));
     }
 
-    public function test_sr_ldr_cannot_update_other_division_tag()
+    #[Test]
+    public function sr_ldr_cannot_update_other_division_tag()
     {
         $srLdr         = $this->createSeniorLeader();
         $otherDivision = $this->createActiveDivision();
@@ -104,7 +114,8 @@ class DivisionTagPolicyTest extends TestCase
         $this->assertFalse($this->policy->update($srLdr, $tag));
     }
 
-    public function test_sr_ldr_cannot_update_global_tag()
+    #[Test]
+    public function sr_ldr_cannot_update_global_tag()
     {
         $srLdr = $this->createSeniorLeader();
         $tag   = DivisionTag::factory()->global()->create();
@@ -112,7 +123,8 @@ class DivisionTagPolicyTest extends TestCase
         $this->assertFalse($this->policy->update($srLdr, $tag));
     }
 
-    public function test_sr_ldr_can_delete_own_division_tag()
+    #[Test]
+    public function sr_ldr_can_delete_own_division_tag()
     {
         $srLdr = $this->createSeniorLeader();
         $tag   = DivisionTag::factory()->create([
@@ -122,7 +134,8 @@ class DivisionTagPolicyTest extends TestCase
         $this->assertTrue($this->policy->delete($srLdr, $tag));
     }
 
-    public function test_sr_ldr_cannot_delete_other_division_tag()
+    #[Test]
+    public function sr_ldr_cannot_delete_other_division_tag()
     {
         $srLdr         = $this->createSeniorLeader();
         $otherDivision = $this->createActiveDivision();
@@ -133,7 +146,8 @@ class DivisionTagPolicyTest extends TestCase
         $this->assertFalse($this->policy->delete($srLdr, $tag));
     }
 
-    public function test_sr_ldr_cannot_delete_global_tag()
+    #[Test]
+    public function sr_ldr_cannot_delete_global_tag()
     {
         $srLdr = $this->createSeniorLeader();
         $tag   = DivisionTag::factory()->global()->create();
@@ -141,14 +155,16 @@ class DivisionTagPolicyTest extends TestCase
         $this->assertFalse($this->policy->delete($srLdr, $tag));
     }
 
-    public function test_sr_ldr_can_assign_tags()
+    #[Test]
+    public function sr_ldr_can_assign_tags()
     {
         $srLdr = $this->createSeniorLeader();
 
         $this->assertTrue($this->policy->assign($srLdr, null));
     }
 
-    public function test_platoon_leader_can_assign_tags()
+    #[Test]
+    public function platoon_leader_can_assign_tags()
     {
         $division = $this->createActiveDivision();
         $platoon  = $this->createPlatoon($division);
@@ -161,7 +177,8 @@ class DivisionTagPolicyTest extends TestCase
         $this->assertTrue($this->policy->assign($user, null));
     }
 
-    public function test_squad_leader_can_assign_tags()
+    #[Test]
+    public function squad_leader_can_assign_tags()
     {
         $division = $this->createActiveDivision();
         $platoon  = $this->createPlatoon($division);
@@ -176,14 +193,16 @@ class DivisionTagPolicyTest extends TestCase
         $this->assertTrue($this->policy->assign($user, null));
     }
 
-    public function test_officer_can_assign_tags()
+    #[Test]
+    public function officer_can_assign_tags()
     {
         $officer = $this->createOfficer();
 
         $this->assertTrue($this->policy->assign($officer, null));
     }
 
-    public function test_member_cannot_assign_tags()
+    #[Test]
+    public function member_cannot_assign_tags()
     {
         $division = $this->createActiveDivision();
         $user     = $this->createMemberWithUser([
@@ -196,7 +215,8 @@ class DivisionTagPolicyTest extends TestCase
         $this->assertFalse($this->policy->assign($user, null));
     }
 
-    public function test_can_assign_to_member_in_same_division()
+    #[Test]
+    public function can_assign_to_member_in_same_division()
     {
         $srLdr  = $this->createSeniorLeader();
         $member = $this->createMember([
@@ -206,7 +226,8 @@ class DivisionTagPolicyTest extends TestCase
         $this->assertTrue($this->policy->assign($srLdr, $member));
     }
 
-    public function test_cannot_assign_to_member_in_different_division()
+    #[Test]
+    public function cannot_assign_to_member_in_different_division()
     {
         $srLdr         = $this->createSeniorLeader();
         $otherDivision = $this->createActiveDivision();

--- a/tests/Unit/Policies/LeavePolicyTest.php
+++ b/tests/Unit/Policies/LeavePolicyTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Policies;
 use App\Enums\Role;
 use App\Policies\LeavePolicy;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Traits\CreatesDivisions;
 use Tests\Traits\CreatesMembers;
@@ -23,7 +24,8 @@ class LeavePolicyTest extends TestCase
         $this->policy = new LeavePolicy;
     }
 
-    public function test_officer_can_create_leave()
+    #[Test]
+    public function officer_can_create_leave()
     {
         $officer = $this->createOfficer();
         $this->actingAs($officer);
@@ -31,7 +33,8 @@ class LeavePolicyTest extends TestCase
         $this->assertTrue($this->policy->create());
     }
 
-    public function test_sr_ldr_can_create_leave()
+    #[Test]
+    public function sr_ldr_can_create_leave()
     {
         $srLdr = $this->createSeniorLeader();
         $this->actingAs($srLdr);
@@ -39,7 +42,8 @@ class LeavePolicyTest extends TestCase
         $this->assertTrue($this->policy->create());
     }
 
-    public function test_admin_can_create_leave()
+    #[Test]
+    public function admin_can_create_leave()
     {
         $admin = $this->createAdmin();
         $this->actingAs($admin);
@@ -47,7 +51,8 @@ class LeavePolicyTest extends TestCase
         $this->assertTrue($this->policy->create());
     }
 
-    public function test_member_cannot_create_leave()
+    #[Test]
+    public function member_cannot_create_leave()
     {
         $division = $this->createActiveDivision();
         $user     = $this->createMemberWithUser([
@@ -60,7 +65,8 @@ class LeavePolicyTest extends TestCase
         $this->assertFalse($this->policy->create());
     }
 
-    public function test_admin_can_update_leave()
+    #[Test]
+    public function admin_can_update_leave()
     {
         $admin = $this->createAdmin();
         $this->actingAs($admin);
@@ -68,7 +74,8 @@ class LeavePolicyTest extends TestCase
         $this->assertTrue($this->policy->update());
     }
 
-    public function test_sr_ldr_can_update_leave()
+    #[Test]
+    public function sr_ldr_can_update_leave()
     {
         $srLdr = $this->createSeniorLeader();
         $this->actingAs($srLdr);
@@ -76,7 +83,8 @@ class LeavePolicyTest extends TestCase
         $this->assertTrue($this->policy->update());
     }
 
-    public function test_officer_cannot_update_leave()
+    #[Test]
+    public function officer_cannot_update_leave()
     {
         $officer = $this->createOfficer();
         $this->actingAs($officer);
@@ -84,7 +92,8 @@ class LeavePolicyTest extends TestCase
         $this->assertFalse($this->policy->update());
     }
 
-    public function test_member_cannot_update_leave()
+    #[Test]
+    public function member_cannot_update_leave()
     {
         $division = $this->createActiveDivision();
         $user     = $this->createMemberWithUser([
@@ -97,7 +106,8 @@ class LeavePolicyTest extends TestCase
         $this->assertFalse($this->policy->update());
     }
 
-    public function test_admin_can_delete_any_leave()
+    #[Test]
+    public function admin_can_delete_any_leave()
     {
         $admin = $this->createAdmin();
         $this->actingAs($admin);
@@ -105,7 +115,8 @@ class LeavePolicyTest extends TestCase
         $this->assertTrue($this->policy->deleteAny());
     }
 
-    public function test_sr_ldr_can_delete_any_leave()
+    #[Test]
+    public function sr_ldr_can_delete_any_leave()
     {
         $srLdr = $this->createSeniorLeader();
         $this->actingAs($srLdr);
@@ -113,7 +124,8 @@ class LeavePolicyTest extends TestCase
         $this->assertTrue($this->policy->deleteAny());
     }
 
-    public function test_officer_cannot_delete_any_leave()
+    #[Test]
+    public function officer_cannot_delete_any_leave()
     {
         $officer = $this->createOfficer();
         $this->actingAs($officer);
@@ -121,7 +133,8 @@ class LeavePolicyTest extends TestCase
         $this->assertFalse($this->policy->deleteAny());
     }
 
-    public function test_member_cannot_delete_any_leave()
+    #[Test]
+    public function member_cannot_delete_any_leave()
     {
         $division = $this->createActiveDivision();
         $user     = $this->createMemberWithUser([

--- a/tests/Unit/Policies/MemberPolicyTest.php
+++ b/tests/Unit/Policies/MemberPolicyTest.php
@@ -6,6 +6,7 @@ use App\Enums\Rank;
 use App\Enums\Role;
 use App\Policies\MemberPolicy;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Traits\CreatesDivisions;
 use Tests\Traits\CreatesMembers;
@@ -24,7 +25,8 @@ class MemberPolicyTest extends TestCase
         $this->policy = new MemberPolicy;
     }
 
-    public function test_admin_bypasses_all_checks()
+    #[Test]
+    public function admin_bypasses_all_checks()
     {
         $admin  = $this->createAdmin();
         $member = $this->createMember(['division_id' => $admin->member->division_id]);
@@ -32,7 +34,8 @@ class MemberPolicyTest extends TestCase
         $this->assertTrue($this->policy->before($admin));
     }
 
-    public function test_developer_bypasses_all_checks()
+    #[Test]
+    public function developer_bypasses_all_checks()
     {
         $division  = $this->createActiveDivision();
         $developer = $this->createMemberWithUser([
@@ -44,7 +47,8 @@ class MemberPolicyTest extends TestCase
         $this->assertTrue($this->policy->before($developer));
     }
 
-    public function test_regular_user_does_not_bypass_checks()
+    #[Test]
+    public function regular_user_does_not_bypass_checks()
     {
         $division = $this->createActiveDivision();
         $user     = $this->createMemberWithUser(['division_id' => $division->id]);
@@ -52,14 +56,16 @@ class MemberPolicyTest extends TestCase
         $this->assertNull($this->policy->before($user));
     }
 
-    public function test_officer_can_recruit()
+    #[Test]
+    public function officer_can_recruit()
     {
         $officer = $this->createOfficer();
 
         $this->assertTrue($this->policy->recruit($officer));
     }
 
-    public function test_member_cannot_recruit()
+    #[Test]
+    public function member_cannot_recruit()
     {
         $division = $this->createActiveDivision();
         $user     = $this->createMemberWithUser([
@@ -71,7 +77,8 @@ class MemberPolicyTest extends TestCase
         $this->assertFalse($this->policy->recruit($user));
     }
 
-    public function test_create_always_returns_false()
+    #[Test]
+    public function create_always_returns_false()
     {
         $admin = $this->createAdmin();
         $user  = $this->createMemberWithUser(['division_id' => $admin->member->division_id]);
@@ -80,7 +87,8 @@ class MemberPolicyTest extends TestCase
         $this->assertFalse($this->policy->create($user));
     }
 
-    public function test_sr_ldr_can_update_other_members()
+    #[Test]
+    public function sr_ldr_can_update_other_members()
     {
         $srLdr  = $this->createSeniorLeader();
         $member = $this->createMember(['division_id' => $srLdr->member->division_id]);
@@ -89,7 +97,8 @@ class MemberPolicyTest extends TestCase
         $this->assertTrue($this->policy->update($srLdr, $member));
     }
 
-    public function test_user_cannot_update_themselves()
+    #[Test]
+    public function user_cannot_update_themselves()
     {
         $srLdr = $this->createSeniorLeader();
 
@@ -97,7 +106,8 @@ class MemberPolicyTest extends TestCase
         $this->assertFalse($this->policy->update($srLdr, $srLdr->member));
     }
 
-    public function test_officer_cannot_update_members()
+    #[Test]
+    public function officer_cannot_update_members()
     {
         $officer = $this->createOfficer();
         $member  = $this->createMember(['division_id' => $officer->member->division_id]);
@@ -106,21 +116,24 @@ class MemberPolicyTest extends TestCase
         $this->assertFalse($this->policy->update($officer, $member));
     }
 
-    public function test_officer_can_flag_inactive()
+    #[Test]
+    public function officer_can_flag_inactive()
     {
         $officer = $this->createOfficer();
 
         $this->assertTrue($this->policy->flagInactive($officer));
     }
 
-    public function test_sr_ldr_can_flag_inactive()
+    #[Test]
+    public function sr_ldr_can_flag_inactive()
     {
         $srLdr = $this->createSeniorLeader();
 
         $this->assertTrue($this->policy->flagInactive($srLdr));
     }
 
-    public function test_member_cannot_flag_inactive()
+    #[Test]
+    public function member_cannot_flag_inactive()
     {
         $division = $this->createActiveDivision();
         $user     = $this->createMemberWithUser([
@@ -132,22 +145,26 @@ class MemberPolicyTest extends TestCase
         $this->assertFalse($this->policy->flagInactive($user));
     }
 
-    public function test_view_returns_true()
+    #[Test]
+    public function view_returns_true()
     {
         $this->assertTrue($this->policy->view());
     }
 
-    public function test_view_any_returns_true()
+    #[Test]
+    public function view_any_returns_true()
     {
         $this->assertTrue($this->policy->viewAny());
     }
 
-    public function test_delete_always_returns_false()
+    #[Test]
+    public function delete_always_returns_false()
     {
         $this->assertFalse($this->policy->delete());
     }
 
-    public function test_sr_ldr_can_separate_lower_rank_member()
+    #[Test]
+    public function sr_ldr_can_separate_lower_rank_member()
     {
         $srLdr  = $this->createSeniorLeader();
         $member = $this->createMember([
@@ -158,7 +175,8 @@ class MemberPolicyTest extends TestCase
         $this->assertTrue($this->policy->separate($srLdr, $member));
     }
 
-    public function test_sr_ldr_cannot_separate_higher_rank_member()
+    #[Test]
+    public function sr_ldr_cannot_separate_higher_rank_member()
     {
         $srLdr  = $this->createSeniorLeader();
         $member = $this->createMember([
@@ -169,14 +187,16 @@ class MemberPolicyTest extends TestCase
         $this->assertFalse($this->policy->separate($srLdr, $member));
     }
 
-    public function test_user_cannot_separate_themselves()
+    #[Test]
+    public function user_cannot_separate_themselves()
     {
         $srLdr = $this->createSeniorLeader();
 
         $this->assertFalse($this->policy->separate($srLdr, $srLdr->member));
     }
 
-    public function test_officer_cannot_separate_members()
+    #[Test]
+    public function officer_cannot_separate_members()
     {
         $officer = $this->createOfficer();
         $member  = $this->createMember([
@@ -187,7 +207,8 @@ class MemberPolicyTest extends TestCase
         $this->assertFalse($this->policy->separate($officer, $member));
     }
 
-    public function test_user_can_manage_own_part_time()
+    #[Test]
+    public function user_can_manage_own_part_time()
     {
         $division = $this->createActiveDivision();
         $user     = $this->createMemberWithUser(['division_id' => $division->id]);
@@ -196,7 +217,8 @@ class MemberPolicyTest extends TestCase
         $this->assertTrue($this->policy->managePartTime($user, $user->member));
     }
 
-    public function test_officer_can_manage_others_part_time()
+    #[Test]
+    public function officer_can_manage_others_part_time()
     {
         $officer = $this->createOfficer();
         $member  = $this->createMember(['division_id' => $officer->member->division_id]);
@@ -205,7 +227,8 @@ class MemberPolicyTest extends TestCase
         $this->assertTrue($this->policy->managePartTime($officer, $member));
     }
 
-    public function test_member_cannot_manage_others_part_time()
+    #[Test]
+    public function member_cannot_manage_others_part_time()
     {
         $division = $this->createActiveDivision();
         $user     = $this->createMemberWithUser([
@@ -220,7 +243,8 @@ class MemberPolicyTest extends TestCase
         $this->assertFalse($this->policy->managePartTime($user, $member));
     }
 
-    public function test_officer_can_promote_within_division()
+    #[Test]
+    public function officer_can_promote_within_division()
     {
         $officer               = $this->createOfficer();
         $officer->member->rank = Rank::STAFF_SERGEANT;
@@ -234,7 +258,8 @@ class MemberPolicyTest extends TestCase
         $this->assertTrue($this->policy->promote($officer, $member));
     }
 
-    public function test_officer_cannot_promote_higher_than_one_below_their_rank()
+    #[Test]
+    public function officer_cannot_promote_higher_than_one_below_their_rank()
     {
         $officer               = $this->createOfficer();
         $officer->member->rank = Rank::STAFF_SERGEANT;
@@ -248,7 +273,8 @@ class MemberPolicyTest extends TestCase
         $this->assertFalse($this->policy->promote($officer, $member));
     }
 
-    public function test_officer_cannot_promote_in_different_division()
+    #[Test]
+    public function officer_cannot_promote_in_different_division()
     {
         $officer               = $this->createOfficer();
         $officer->member->rank = Rank::MASTER_SERGEANT;
@@ -263,7 +289,8 @@ class MemberPolicyTest extends TestCase
         $this->assertFalse($this->policy->promote($officer, $member));
     }
 
-    public function test_member_cannot_promote()
+    #[Test]
+    public function member_cannot_promote()
     {
         $division = $this->createActiveDivision();
         $user     = $this->createMemberWithUser([
@@ -280,7 +307,8 @@ class MemberPolicyTest extends TestCase
         $this->assertFalse($this->policy->promote($user, $member));
     }
 
-    public function test_user_can_manage_own_handles()
+    #[Test]
+    public function user_can_manage_own_handles()
     {
         $division = $this->createActiveDivision();
         $user     = $this->createMemberWithUser(['division_id' => $division->id]);
@@ -289,7 +317,8 @@ class MemberPolicyTest extends TestCase
         $this->assertTrue($this->policy->manageIngameHandles($user, $user->member));
     }
 
-    public function test_officer_can_manage_others_handles()
+    #[Test]
+    public function officer_can_manage_others_handles()
     {
         $officer = $this->createOfficer();
         $member  = $this->createMember(['division_id' => $officer->member->division_id]);

--- a/tests/Unit/Policies/RankActionPolicyTest.php
+++ b/tests/Unit/Policies/RankActionPolicyTest.php
@@ -8,6 +8,7 @@ use App\Enums\Role;
 use App\Models\RankAction;
 use App\Policies\RankActionPolicy;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Traits\CreatesDivisions;
 use Tests\Traits\CreatesMembers;
@@ -18,7 +19,8 @@ class RankActionPolicyTest extends TestCase
     use CreatesMembers;
     use RefreshDatabase;
 
-    public function test_admin_can_view_any_rank_action()
+    #[Test]
+    public function admin_can_view_any_rank_action()
     {
         $admin    = $this->createAdmin();
         $division = $this->createActiveDivision();
@@ -32,7 +34,8 @@ class RankActionPolicyTest extends TestCase
         $this->assertTrue(RankActionPolicy::update($admin, $action));
     }
 
-    public function test_user_cannot_view_own_rank_action()
+    #[Test]
+    public function user_cannot_view_own_rank_action()
     {
         $division = $this->createActiveDivision();
         $user     = $this->createMemberWithUser([
@@ -49,7 +52,8 @@ class RankActionPolicyTest extends TestCase
         $this->assertFalse(RankActionPolicy::update($user, $action));
     }
 
-    public function test_requester_can_view_their_request()
+    #[Test]
+    public function requester_can_view_their_request()
     {
         $division  = $this->createActiveDivision();
         $requester = $this->createMemberWithUser(['division_id' => $division->id]);
@@ -64,7 +68,8 @@ class RankActionPolicyTest extends TestCase
         $this->assertTrue(RankActionPolicy::update($requester, $action));
     }
 
-    public function test_division_leader_can_view_division_requests_below_ssgt()
+    #[Test]
+    public function division_leader_can_view_division_requests_below_ssgt()
     {
         $division = $this->createActiveDivision();
         $platoon  = $this->createPlatoon($division);
@@ -88,7 +93,8 @@ class RankActionPolicyTest extends TestCase
         $this->assertTrue(RankActionPolicy::update($leader, $action));
     }
 
-    public function test_division_leader_can_view_staff_sergeant_requests()
+    #[Test]
+    public function division_leader_can_view_staff_sergeant_requests()
     {
         $division = $this->createActiveDivision();
         $platoon  = $this->createPlatoon($division);
@@ -112,7 +118,8 @@ class RankActionPolicyTest extends TestCase
         $this->assertTrue(RankActionPolicy::update($leader, $action));
     }
 
-    public function test_division_leader_cannot_view_master_sergeant_requests()
+    #[Test]
+    public function division_leader_cannot_view_master_sergeant_requests()
     {
         $division = $this->createActiveDivision();
         $platoon  = $this->createPlatoon($division);
@@ -136,7 +143,8 @@ class RankActionPolicyTest extends TestCase
         $this->assertFalse(RankActionPolicy::update($leader, $action));
     }
 
-    public function test_platoon_leader_can_view_platoon_requests_below_their_rank()
+    #[Test]
+    public function platoon_leader_can_view_platoon_requests_below_their_rank()
     {
         $division = $this->createActiveDivision();
         $platoon  = $this->createPlatoon($division);
@@ -161,7 +169,8 @@ class RankActionPolicyTest extends TestCase
         $this->assertTrue(RankActionPolicy::update($leader, $action));
     }
 
-    public function test_platoon_leader_cannot_view_requests_equal_to_their_rank()
+    #[Test]
+    public function platoon_leader_cannot_view_requests_equal_to_their_rank()
     {
         $division = $this->createActiveDivision();
         $platoon  = $this->createPlatoon($division);
@@ -186,7 +195,8 @@ class RankActionPolicyTest extends TestCase
         $this->assertFalse(RankActionPolicy::update($leader, $action));
     }
 
-    public function test_platoon_leader_cannot_view_requests_from_other_platoons()
+    #[Test]
+    public function platoon_leader_cannot_view_requests_from_other_platoons()
     {
         $division = $this->createActiveDivision();
         $platoon1 = $this->createPlatoon($division);
@@ -212,7 +222,8 @@ class RankActionPolicyTest extends TestCase
         $this->assertFalse(RankActionPolicy::update($leader, $action));
     }
 
-    public function test_delete_any_requires_admin_role()
+    #[Test]
+    public function delete_any_requires_admin_role()
     {
         $admin = $this->createAdmin();
         $this->actingAs($admin);
@@ -220,7 +231,8 @@ class RankActionPolicyTest extends TestCase
         $this->assertTrue(RankActionPolicy::deleteAny());
     }
 
-    public function test_non_admin_cannot_delete_any()
+    #[Test]
+    public function non_admin_cannot_delete_any()
     {
         $officer = $this->createOfficer();
         $this->actingAs($officer);

--- a/tests/Unit/Policies/TransferPolicyTest.php
+++ b/tests/Unit/Policies/TransferPolicyTest.php
@@ -6,6 +6,7 @@ use App\Enums\Position;
 use App\Models\Transfer;
 use App\Policies\TransferPolicy;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Traits\CreatesDivisions;
 use Tests\Traits\CreatesMembers;
@@ -24,14 +25,16 @@ class TransferPolicyTest extends TestCase
         $this->policy = new TransferPolicy;
     }
 
-    public function test_admin_bypasses_all_checks()
+    #[Test]
+    public function admin_bypasses_all_checks()
     {
         $admin = $this->createAdmin();
 
         $this->assertTrue($this->policy->before($admin));
     }
 
-    public function test_developer_bypasses_all_checks()
+    #[Test]
+    public function developer_bypasses_all_checks()
     {
         $division  = $this->createActiveDivision();
         $developer = $this->createMemberWithUser([
@@ -43,7 +46,8 @@ class TransferPolicyTest extends TestCase
         $this->assertTrue($this->policy->before($developer));
     }
 
-    public function test_regular_user_does_not_bypass_checks()
+    #[Test]
+    public function regular_user_does_not_bypass_checks()
     {
         $division = $this->createActiveDivision();
         $user     = $this->createMemberWithUser(['division_id' => $division->id]);
@@ -51,7 +55,8 @@ class TransferPolicyTest extends TestCase
         $this->assertNull($this->policy->before($user));
     }
 
-    public function test_user_can_create_transfer_in_active_division()
+    #[Test]
+    public function user_can_create_transfer_in_active_division()
     {
         $division = $this->createActiveDivision();
         $user     = $this->createMemberWithUser(['division_id' => $division->id]);
@@ -59,7 +64,8 @@ class TransferPolicyTest extends TestCase
         $this->assertTrue($this->policy->create($user));
     }
 
-    public function test_user_cannot_create_transfer_in_inactive_division()
+    #[Test]
+    public function user_cannot_create_transfer_in_inactive_division()
     {
         $division         = $this->createActiveDivision();
         $division->active = false;
@@ -71,7 +77,8 @@ class TransferPolicyTest extends TestCase
         $this->assertFalse($this->policy->create($user));
     }
 
-    public function test_division_leader_can_approve_transfer_to_their_division()
+    #[Test]
+    public function division_leader_can_approve_transfer_to_their_division()
     {
         $fromDivision = $this->createActiveDivision();
         $toDivision   = $this->createActiveDivision();
@@ -93,7 +100,8 @@ class TransferPolicyTest extends TestCase
         $this->assertTrue($this->policy->approve($leader, $transfer));
     }
 
-    public function test_division_leader_cannot_approve_transfer_to_other_division()
+    #[Test]
+    public function division_leader_cannot_approve_transfer_to_other_division()
     {
         $fromDivision   = $this->createActiveDivision();
         $toDivision     = $this->createActiveDivision();
@@ -116,7 +124,8 @@ class TransferPolicyTest extends TestCase
         $this->assertFalse($this->policy->approve($leader, $transfer));
     }
 
-    public function test_non_division_leader_cannot_approve_transfer()
+    #[Test]
+    public function non_division_leader_cannot_approve_transfer()
     {
         $fromDivision = $this->createActiveDivision();
         $toDivision   = $this->createActiveDivision();
@@ -138,7 +147,8 @@ class TransferPolicyTest extends TestCase
         $this->assertFalse($this->policy->approve($user, $transfer));
     }
 
-    public function test_executive_officer_can_approve_transfer()
+    #[Test]
+    public function executive_officer_can_approve_transfer()
     {
         $fromDivision = $this->createActiveDivision();
         $toDivision   = $this->createActiveDivision();
@@ -160,7 +170,8 @@ class TransferPolicyTest extends TestCase
         $this->assertTrue($this->policy->approve($xo, $transfer));
     }
 
-    public function test_division_leader_can_delete_pending_transfer()
+    #[Test]
+    public function division_leader_can_delete_pending_transfer()
     {
         $fromDivision = $this->createActiveDivision();
         $toDivision   = $this->createActiveDivision();
@@ -180,7 +191,8 @@ class TransferPolicyTest extends TestCase
         $this->assertTrue($this->policy->delete($leader, $transfer));
     }
 
-    public function test_division_leader_cannot_delete_approved_transfer()
+    #[Test]
+    public function division_leader_cannot_delete_approved_transfer()
     {
         $fromDivision = $this->createActiveDivision();
         $toDivision   = $this->createActiveDivision();
@@ -200,7 +212,8 @@ class TransferPolicyTest extends TestCase
         $this->assertFalse($this->policy->delete($leader, $transfer));
     }
 
-    public function test_division_leader_cannot_delete_transfer_to_other_division()
+    #[Test]
+    public function division_leader_cannot_delete_transfer_to_other_division()
     {
         $fromDivision   = $this->createActiveDivision();
         $toDivision     = $this->createActiveDivision();
@@ -221,7 +234,8 @@ class TransferPolicyTest extends TestCase
         $this->assertFalse($this->policy->delete($leader, $transfer));
     }
 
-    public function test_losing_division_leader_can_hold_pending_transfer()
+    #[Test]
+    public function losing_division_leader_can_hold_pending_transfer()
     {
         $fromDivision = $this->createActiveDivision();
         $toDivision   = $this->createActiveDivision();
@@ -241,7 +255,8 @@ class TransferPolicyTest extends TestCase
         $this->assertTrue($this->policy->hold($leader, $transfer));
     }
 
-    public function test_losing_division_leader_can_delete_pending_transfer()
+    #[Test]
+    public function losing_division_leader_can_delete_pending_transfer()
     {
         $fromDivision = $this->createActiveDivision();
         $toDivision   = $this->createActiveDivision();
@@ -261,7 +276,8 @@ class TransferPolicyTest extends TestCase
         $this->assertTrue($this->policy->delete($leader, $transfer));
     }
 
-    public function test_gaining_division_leader_can_hold_pending_transfer()
+    #[Test]
+    public function gaining_division_leader_can_hold_pending_transfer()
     {
         $fromDivision = $this->createActiveDivision();
         $toDivision   = $this->createActiveDivision();
@@ -281,7 +297,8 @@ class TransferPolicyTest extends TestCase
         $this->assertTrue($this->policy->hold($leader, $transfer));
     }
 
-    public function test_cannot_hold_approved_transfer()
+    #[Test]
+    public function cannot_hold_approved_transfer()
     {
         $fromDivision = $this->createActiveDivision();
         $toDivision   = $this->createActiveDivision();
@@ -301,7 +318,8 @@ class TransferPolicyTest extends TestCase
         $this->assertFalse($this->policy->hold($leader, $transfer));
     }
 
-    public function test_unrelated_division_leader_cannot_hold_transfer()
+    #[Test]
+    public function unrelated_division_leader_cannot_hold_transfer()
     {
         $fromDivision  = $this->createActiveDivision();
         $toDivision    = $this->createActiveDivision();

--- a/tests/Unit/Repositories/MemberRepositoryTest.php
+++ b/tests/Unit/Repositories/MemberRepositoryTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit\Repositories;
 
 use App\Repositories\MemberRepository;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Traits\CreatesDivisions;
 use Tests\Traits\CreatesMembers;
@@ -22,7 +23,8 @@ class MemberRepositoryTest extends TestCase
         $this->repository = new MemberRepository;
     }
 
-    public function test_search_finds_member_by_name()
+    #[Test]
+    public function search_finds_member_by_name()
     {
         $division = $this->createActiveDivision();
         $member   = $this->createMember(['name' => 'TestMember', 'division_id' => $division->id]);
@@ -33,7 +35,8 @@ class MemberRepositoryTest extends TestCase
         $this->assertEquals($member->id, $results->first()->id);
     }
 
-    public function test_search_finds_member_by_partial_name()
+    #[Test]
+    public function search_finds_member_by_partial_name()
     {
         $division = $this->createActiveDivision();
         $this->createMember(['name' => 'JohnDoe', 'division_id' => $division->id]);
@@ -43,7 +46,8 @@ class MemberRepositoryTest extends TestCase
         $this->assertCount(1, $results);
     }
 
-    public function test_search_with_backslash_does_not_throw_error()
+    #[Test]
+    public function search_with_backslash_does_not_throw_error()
     {
         $division = $this->createActiveDivision();
         $this->createMember(['name' => 'TestMember', 'division_id' => $division->id]);
@@ -53,7 +57,8 @@ class MemberRepositoryTest extends TestCase
         $this->assertCount(0, $results);
     }
 
-    public function test_search_with_percent_does_not_match_wildcard()
+    #[Test]
+    public function search_with_percent_does_not_match_wildcard()
     {
         $division = $this->createActiveDivision();
         $this->createMember(['name' => 'Alice', 'division_id' => $division->id]);
@@ -64,7 +69,8 @@ class MemberRepositoryTest extends TestCase
         $this->assertCount(0, $results);
     }
 
-    public function test_search_with_underscore_does_not_match_single_char_wildcard()
+    #[Test]
+    public function search_with_underscore_does_not_match_single_char_wildcard()
     {
         $division = $this->createActiveDivision();
         $this->createMember(['name' => 'Cat', 'division_id' => $division->id]);
@@ -75,7 +81,8 @@ class MemberRepositoryTest extends TestCase
         $this->assertCount(0, $results);
     }
 
-    public function test_search_finds_member_with_literal_special_chars_in_name()
+    #[Test]
+    public function search_finds_member_with_literal_special_chars_in_name()
     {
         $division = $this->createActiveDivision();
         $this->createMember(['name' => 'Test_Member', 'division_id' => $division->id]);
@@ -85,7 +92,8 @@ class MemberRepositoryTest extends TestCase
         $this->assertCount(1, $results);
     }
 
-    public function test_autocomplete_finds_member_by_name()
+    #[Test]
+    public function autocomplete_finds_member_by_name()
     {
         $division = $this->createActiveDivision();
         $member   = $this->createMember(['name' => 'SearchableUser', 'division_id' => $division->id]);
@@ -97,7 +105,8 @@ class MemberRepositoryTest extends TestCase
         $this->assertEquals('SearchableUser', $results->first()['label']);
     }
 
-    public function test_autocomplete_with_backslash_does_not_throw_error()
+    #[Test]
+    public function autocomplete_with_backslash_does_not_throw_error()
     {
         $division = $this->createActiveDivision();
         $this->createMember(['name' => 'TestUser', 'division_id' => $division->id]);
@@ -107,7 +116,8 @@ class MemberRepositoryTest extends TestCase
         $this->assertCount(0, $results);
     }
 
-    public function test_autocomplete_with_percent_does_not_match_all()
+    #[Test]
+    public function autocomplete_with_percent_does_not_match_all()
     {
         $division = $this->createActiveDivision();
         $this->createMember(['name' => 'User1', 'division_id' => $division->id]);
@@ -118,7 +128,8 @@ class MemberRepositoryTest extends TestCase
         $this->assertCount(0, $results);
     }
 
-    public function test_autocomplete_respects_limit()
+    #[Test]
+    public function autocomplete_respects_limit()
     {
         $division = $this->createActiveDivision();
         for ($i = 1; $i <= 10; $i++) {

--- a/tests/Unit/Services/AODBotServiceTest.php
+++ b/tests/Unit/Services/AODBotServiceTest.php
@@ -8,6 +8,7 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Psr\Http\Message\ResponseInterface;
 use Tests\TestCase;
 use Tests\Traits\CreatesMembers;
@@ -33,7 +34,8 @@ class AODBotServiceTest extends TestCase
         return $service;
     }
 
-    public function test_get_forum_member_makes_request_to_correct_url()
+    #[Test]
+    public function get_forum_member_makes_request_to_correct_url()
     {
         config(['aod.bot_api_base_url' => 'https://bot.example.com']);
         config(['aod.discord_bot_token' => 'test-token']);
@@ -47,7 +49,8 @@ class AODBotServiceTest extends TestCase
         $this->assertEquals(200, $response->getStatusCode());
     }
 
-    public function test_get_forum_member_returns_response_interface()
+    #[Test]
+    public function get_forum_member_returns_response_interface()
     {
         config(['aod.bot_api_base_url' => 'https://bot.example.com']);
         config(['aod.discord_bot_token' => 'test-token']);
@@ -61,7 +64,8 @@ class AODBotServiceTest extends TestCase
         $this->assertInstanceOf(ResponseInterface::class, $response);
     }
 
-    public function test_get_forum_member_response_body_contains_member_data()
+    #[Test]
+    public function get_forum_member_response_body_contains_member_data()
     {
         config(['aod.bot_api_base_url' => 'https://bot.example.com']);
         config(['aod.discord_bot_token' => 'test-token']);
@@ -78,7 +82,8 @@ class AODBotServiceTest extends TestCase
         $this->assertEquals($expectedData, $body);
     }
 
-    public function test_update_discord_member_makes_request()
+    #[Test]
+    public function update_discord_member_makes_request()
     {
         config(['aod.bot_api_base_url' => 'https://bot.example.com']);
         config(['aod.discord_bot_token' => 'test-token']);
@@ -92,7 +97,8 @@ class AODBotServiceTest extends TestCase
         $this->assertEquals(200, $response->getStatusCode());
     }
 
-    public function test_update_discord_member_returns_response_with_status()
+    #[Test]
+    public function update_discord_member_returns_response_with_status()
     {
         config(['aod.bot_api_base_url' => 'https://bot.example.com']);
         config(['aod.discord_bot_token' => 'test-token']);
@@ -108,7 +114,8 @@ class AODBotServiceTest extends TestCase
         $this->assertTrue($body['updated']);
     }
 
-    public function test_service_includes_authorization_header()
+    #[Test]
+    public function service_includes_authorization_header()
     {
         config(['aod.bot_api_base_url' => 'https://bot.example.com']);
         config(['aod.discord_bot_token' => 'test-bot-token']);
@@ -138,7 +145,8 @@ class AODBotServiceTest extends TestCase
         $this->assertStringContainsString('Bearer', $requestedHeaders['Authorization'][0]);
     }
 
-    public function test_service_includes_content_type_header()
+    #[Test]
+    public function service_includes_content_type_header()
     {
         config(['aod.bot_api_base_url' => 'https://bot.example.com']);
         config(['aod.discord_bot_token' => 'test-bot-token']);

--- a/tests/Unit/Services/AODForumServiceTest.php
+++ b/tests/Unit/Services/AODForumServiceTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Services;
 use App\Services\AODForumService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
+use PHPUnit\Framework\Attributes\Test;
 use RuntimeException;
 use Tests\TestCase;
 
@@ -18,7 +19,8 @@ class AODForumServiceTest extends TestCase
         config(['aod.token' => 'test-token']);
     }
 
-    public function test_request_makes_http_get_with_auth_token()
+    #[Test]
+    public function request_makes_http_get_with_auth_token()
     {
         Http::fake([
             '*' => Http::response('success', 200),
@@ -31,7 +33,8 @@ class AODForumServiceTest extends TestCase
         });
     }
 
-    public function test_request_uses_custom_token_param()
+    #[Test]
+    public function request_uses_custom_token_param()
     {
         Http::fake([
             '*' => Http::response('success', 200),
@@ -44,7 +47,8 @@ class AODForumServiceTest extends TestCase
         });
     }
 
-    public function test_request_returns_json_when_response_is_json()
+    #[Test]
+    public function request_returns_json_when_response_is_json()
     {
         Http::fake([
             '*' => Http::response(['status' => 'ok', 'data' => 'test'], 200),
@@ -56,7 +60,8 @@ class AODForumServiceTest extends TestCase
         $this->assertEquals('ok', $result['status']);
     }
 
-    public function test_request_returns_last_word_when_response_is_not_json()
+    #[Test]
+    public function request_returns_last_word_when_response_is_not_json()
     {
         Http::fake([
             '*' => Http::response('<html>Some text result</html>', 200),
@@ -67,7 +72,8 @@ class AODForumServiceTest extends TestCase
         $this->assertEquals('result', $result);
     }
 
-    public function test_request_returns_error_message_on_exception()
+    #[Test]
+    public function request_returns_error_message_on_exception()
     {
         Http::fake([
             '*' => Http::response('', 500),
@@ -82,7 +88,8 @@ class AODForumServiceTest extends TestCase
         $this->assertEquals('Error: Invalid user context', $result);
     }
 
-    public function test_add_forum_member_sends_correct_parameters()
+    #[Test]
+    public function add_forum_member_sends_correct_parameters()
     {
         Http::fake([
             '*' => Http::response('saved_user_x_successfully', 200),
@@ -108,7 +115,8 @@ class AODForumServiceTest extends TestCase
         });
     }
 
-    public function test_add_forum_member_does_not_throw_on_success()
+    #[Test]
+    public function add_forum_member_does_not_throw_on_success()
     {
         Http::fake([
             '*' => Http::response('saved_user_x_successfully', 200),
@@ -119,7 +127,8 @@ class AODForumServiceTest extends TestCase
         $this->assertNotNull($result);
     }
 
-    public function test_add_forum_member_throws_exception_on_failure()
+    #[Test]
+    public function add_forum_member_throws_exception_on_failure()
     {
         Http::fake([
             '*' => Http::response('error_invalid_user', 200),
@@ -131,7 +140,8 @@ class AODForumServiceTest extends TestCase
         AODForumService::addForumMember(12345, 67890, 'PFC', 'TestMember', 'Test');
     }
 
-    public function test_remove_forum_member_sends_correct_parameters()
+    #[Test]
+    public function remove_forum_member_sends_correct_parameters()
     {
         Http::fake([
             '*' => Http::response('saved_user_x_successfully', 200),
@@ -151,7 +161,8 @@ class AODForumServiceTest extends TestCase
         });
     }
 
-    public function test_remove_forum_member_does_not_throw_on_success()
+    #[Test]
+    public function remove_forum_member_does_not_throw_on_success()
     {
         Http::fake([
             '*' => Http::response('saved_user_x_successfully', 200),
@@ -162,7 +173,8 @@ class AODForumServiceTest extends TestCase
         $this->assertNotNull($result);
     }
 
-    public function test_remove_forum_member_throws_exception_on_failure()
+    #[Test]
+    public function remove_forum_member_throws_exception_on_failure()
     {
         Http::fake([
             '*' => Http::response('error_user_not_found', 200),
@@ -174,7 +186,8 @@ class AODForumServiceTest extends TestCase
         AODForumService::removeForumMember(67890, 12345);
     }
 
-    public function test_fetch_info_calls_info_url()
+    #[Test]
+    public function fetch_info_calls_info_url()
     {
         Http::fake([
             'https://www.clanaod.net/forums/aodinfo.php*' => Http::response(['status' => 'ok'], 200),
@@ -188,7 +201,8 @@ class AODForumServiceTest extends TestCase
         });
     }
 
-    public function test_fetch_info_passes_params()
+    #[Test]
+    public function fetch_info_passes_params()
     {
         Http::fake([
             '*' => Http::response(['name' => 'TestUser'], 200),

--- a/tests/Unit/Services/DivisionShowServiceTest.php
+++ b/tests/Unit/Services/DivisionShowServiceTest.php
@@ -9,6 +9,7 @@ use App\Models\Census;
 use App\Services\DivisionShowService;
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Traits\CreatesDivisions;
 use Tests\Traits\CreatesMembers;
@@ -27,7 +28,8 @@ class DivisionShowServiceTest extends TestCase
         $this->service = app(DivisionShowService::class);
     }
 
-    public function test_get_show_data_returns_division_show_data_object()
+    #[Test]
+    public function get_show_data_returns_division_show_data_object()
     {
         $division = $this->createActiveDivision();
         $user     = $this->createMemberWithUser(['division_id' => $division->id]);
@@ -38,7 +40,8 @@ class DivisionShowServiceTest extends TestCase
         $this->assertInstanceOf(DivisionShowData::class, $result);
     }
 
-    public function test_get_show_data_includes_division()
+    #[Test]
+    public function get_show_data_includes_division()
     {
         $division = $this->createActiveDivision();
         $user     = $this->createMemberWithUser(['division_id' => $division->id]);
@@ -49,7 +52,8 @@ class DivisionShowServiceTest extends TestCase
         $this->assertTrue($result->division->is($division));
     }
 
-    public function test_get_show_data_includes_stats()
+    #[Test]
+    public function get_show_data_includes_stats()
     {
         $division = $this->createActiveDivision();
         $user     = $this->createMemberWithUser(['division_id' => $division->id]);
@@ -60,7 +64,8 @@ class DivisionShowServiceTest extends TestCase
         $this->assertNotNull($result->stats);
     }
 
-    public function test_get_show_data_includes_chart_data()
+    #[Test]
+    public function get_show_data_includes_chart_data()
     {
         $division = $this->createActiveDivision();
         $user     = $this->createMemberWithUser(['division_id' => $division->id]);
@@ -71,7 +76,8 @@ class DivisionShowServiceTest extends TestCase
         $this->assertNotNull($result->chartData);
     }
 
-    public function test_get_show_data_includes_platoons()
+    #[Test]
+    public function get_show_data_includes_platoons()
     {
         $division = $this->createActiveDivision();
         $platoon  = $this->createPlatoon($division);
@@ -83,7 +89,8 @@ class DivisionShowServiceTest extends TestCase
         $this->assertCount(1, $result->platoons);
     }
 
-    public function test_get_show_data_platoons_ordered_by_order_field()
+    #[Test]
+    public function get_show_data_platoons_ordered_by_order_field()
     {
         $division = $this->createActiveDivision();
         $platoon2 = $this->createPlatoon($division, ['order' => 2, 'name' => 'Second Platoon']);
@@ -97,7 +104,8 @@ class DivisionShowServiceTest extends TestCase
         $this->assertEquals('Second Platoon', $result->platoons->last()->name);
     }
 
-    public function test_get_show_data_platoons_include_member_count()
+    #[Test]
+    public function get_show_data_platoons_include_member_count()
     {
         $division = $this->createActiveDivision();
         $platoon  = $this->createPlatoon($division);
@@ -117,7 +125,8 @@ class DivisionShowServiceTest extends TestCase
         $this->assertEquals(2, $result->platoons->first()->members_count);
     }
 
-    public function test_get_show_data_platoons_include_voice_active_count()
+    #[Test]
+    public function get_show_data_platoons_include_voice_active_count()
     {
         $division = $this->createActiveDivision();
         $platoon  = $this->createPlatoon($division);
@@ -140,7 +149,8 @@ class DivisionShowServiceTest extends TestCase
         $this->assertEquals(1, $result->platoons->first()->voice_active_count);
     }
 
-    public function test_get_show_data_includes_division_leaders()
+    #[Test]
+    public function get_show_data_includes_division_leaders()
     {
         $division = $this->createActiveDivision();
         $co       = $this->createCommander($division);
@@ -153,7 +163,8 @@ class DivisionShowServiceTest extends TestCase
         $this->assertCount(2, $result->divisionLeaders);
     }
 
-    public function test_get_show_data_includes_general_sergeants()
+    #[Test]
+    public function get_show_data_includes_general_sergeants()
     {
         $division  = $this->createActiveDivision();
         $clanAdmin = $this->createMember([
@@ -169,7 +180,8 @@ class DivisionShowServiceTest extends TestCase
         $this->assertCount(1, $result->generalSergeants);
     }
 
-    public function test_get_show_data_includes_pending_actions()
+    #[Test]
+    public function get_show_data_includes_pending_actions()
     {
         $division = $this->createActiveDivision();
         $user     = $this->createMemberWithUser(['division_id' => $division->id]);
@@ -180,7 +192,8 @@ class DivisionShowServiceTest extends TestCase
         $this->assertNotNull($result->pendingActions);
     }
 
-    public function test_get_show_data_includes_division_anniversaries()
+    #[Test]
+    public function get_show_data_includes_division_anniversaries()
     {
         $division = $this->createActiveDivision();
         $this->createMember([
@@ -195,7 +208,8 @@ class DivisionShowServiceTest extends TestCase
         $this->assertNotNull($result->divisionAnniversaries);
     }
 
-    public function test_get_show_data_includes_previous_census()
+    #[Test]
+    public function get_show_data_includes_previous_census()
     {
         $division = $this->createActiveDivision();
         Census::factory()->create([
@@ -211,7 +225,8 @@ class DivisionShowServiceTest extends TestCase
         $this->assertNotNull($result->previousCensus);
     }
 
-    public function test_get_show_data_platoons_load_squads()
+    #[Test]
+    public function get_show_data_platoons_load_squads()
     {
         $division = $this->createActiveDivision();
         $platoon  = $this->createPlatoon($division);
@@ -225,7 +240,8 @@ class DivisionShowServiceTest extends TestCase
         $this->assertCount(1, $result->platoons->first()->squads);
     }
 
-    public function test_get_show_data_platoons_load_leaders()
+    #[Test]
+    public function get_show_data_platoons_load_leaders()
     {
         $division = $this->createActiveDivision();
         $platoon  = $this->createPlatoon($division);

--- a/tests/Unit/Services/MemberQueryServiceTest.php
+++ b/tests/Unit/Services/MemberQueryServiceTest.php
@@ -7,6 +7,7 @@ use App\Models\Handle;
 use App\Models\Member;
 use App\Services\MemberQueryService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Traits\CreatesDivisions;
 use Tests\Traits\CreatesMembers;
@@ -25,7 +26,8 @@ class MemberQueryServiceTest extends TestCase
         $this->service = new MemberQueryService;
     }
 
-    public function test_with_standard_relations_includes_handles()
+    #[Test]
+    public function with_standard_relations_includes_handles()
     {
         $division = $this->createActiveDivision();
         $member   = $this->createMember(['division_id' => $division->id]);
@@ -37,7 +39,8 @@ class MemberQueryServiceTest extends TestCase
         $this->assertTrue($result->relationLoaded('handles'));
     }
 
-    public function test_with_standard_relations_includes_leave()
+    #[Test]
+    public function with_standard_relations_includes_leave()
     {
         $division = $this->createActiveDivision();
         $member   = $this->createMember(['division_id' => $division->id]);
@@ -48,7 +51,8 @@ class MemberQueryServiceTest extends TestCase
         $this->assertTrue($result->relationLoaded('leave'));
     }
 
-    public function test_with_standard_relations_includes_tags()
+    #[Test]
+    public function with_standard_relations_includes_tags()
     {
         $division = $this->createActiveDivision();
         $member   = $this->createMember(['division_id' => $division->id]);
@@ -59,7 +63,8 @@ class MemberQueryServiceTest extends TestCase
         $this->assertTrue($result->relationLoaded('tags'));
     }
 
-    public function test_with_standard_relations_includes_platoon()
+    #[Test]
+    public function with_standard_relations_includes_platoon()
     {
         $division = $this->createActiveDivision();
         $platoon  = $this->createPlatoon($division);
@@ -74,7 +79,8 @@ class MemberQueryServiceTest extends TestCase
         $this->assertTrue($result->relationLoaded('platoon'));
     }
 
-    public function test_with_standard_relations_includes_squad()
+    #[Test]
+    public function with_standard_relations_includes_squad()
     {
         $division = $this->createActiveDivision();
         $platoon  = $this->createPlatoon($division);
@@ -91,7 +97,8 @@ class MemberQueryServiceTest extends TestCase
         $this->assertTrue($result->relationLoaded('squad'));
     }
 
-    public function test_primary_handle_constraint_filters_to_division_handle()
+    #[Test]
+    public function primary_handle_constraint_filters_to_division_handle()
     {
         $division    = $this->createActiveDivision();
         $otherHandle = Handle::factory()->create();
@@ -107,7 +114,8 @@ class MemberQueryServiceTest extends TestCase
         $this->assertEquals('primary_handle', $result->handles->first()->pivot->value);
     }
 
-    public function test_extract_handles_sets_handle_attribute_on_members()
+    #[Test]
+    public function extract_handles_sets_handle_attribute_on_members()
     {
         $division = $this->createActiveDivision();
         $member   = $this->createMember(['division_id' => $division->id]);
@@ -121,7 +129,8 @@ class MemberQueryServiceTest extends TestCase
         $this->assertEquals($division->handle_id, $result->first()->handle->id);
     }
 
-    public function test_load_sorted_members_sorts_by_rank_descending()
+    #[Test]
+    public function load_sorted_members_sorts_by_rank_descending()
     {
         $division = $this->createActiveDivision();
 
@@ -146,7 +155,8 @@ class MemberQueryServiceTest extends TestCase
         $this->assertEquals($private->id, $result->last()->id);
     }
 
-    public function test_load_sorted_members_extracts_handles()
+    #[Test]
+    public function load_sorted_members_extracts_handles()
     {
         $division = $this->createActiveDivision();
         $member   = $this->createMember(['division_id' => $division->id]);

--- a/tests/Unit/Services/MemberSyncServiceTest.php
+++ b/tests/Unit/Services/MemberSyncServiceTest.php
@@ -8,13 +8,15 @@ use App\Models\Member;
 use App\Services\MemberSyncService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Mockery;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class MemberSyncServiceTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_sync_returns_false_when_no_data(): void
+    #[Test]
+    public function sync_returns_false_when_no_data(): void
     {
         $mockInfo       = Mockery::mock(GetDivisionInfo::class);
         $mockInfo->data = null;
@@ -24,7 +26,8 @@ class MemberSyncServiceTest extends TestCase
         $this->assertFalse($service->sync());
     }
 
-    public function test_sync_returns_true_with_valid_data(): void
+    #[Test]
+    public function sync_returns_true_with_valid_data(): void
     {
         $division = Division::factory()->create();
 
@@ -53,7 +56,8 @@ class MemberSyncServiceTest extends TestCase
         $this->assertTrue($service->sync());
     }
 
-    public function test_sync_creates_new_members(): void
+    #[Test]
+    public function sync_creates_new_members(): void
     {
         $division = Division::factory()->create();
 
@@ -89,7 +93,8 @@ class MemberSyncServiceTest extends TestCase
         $this->assertEquals(1, $stats['added']);
     }
 
-    public function test_sync_updates_existing_members(): void
+    #[Test]
+    public function sync_updates_existing_members(): void
     {
         $division = Division::factory()->create();
         $member   = Member::factory()->create([
@@ -130,7 +135,8 @@ class MemberSyncServiceTest extends TestCase
         $this->assertEquals(1, $stats['updated']);
     }
 
-    public function test_callbacks_are_invoked(): void
+    #[Test]
+    public function callbacks_are_invoked(): void
     {
         $division = Division::factory()->create();
 
@@ -167,7 +173,8 @@ class MemberSyncServiceTest extends TestCase
         $this->assertEquals('AOD_CallbackTest', $addedMembers[0]['name']);
     }
 
-    public function test_get_stats_returns_sync_statistics(): void
+    #[Test]
+    public function get_stats_returns_sync_statistics(): void
     {
         $mockInfo       = Mockery::mock(GetDivisionInfo::class);
         $mockInfo->data = [];
@@ -182,7 +189,8 @@ class MemberSyncServiceTest extends TestCase
         $this->assertArrayHasKey('errors', $stats);
     }
 
-    public function test_skips_members_with_none_division(): void
+    #[Test]
+    public function skips_members_with_none_division(): void
     {
         $mockInfo       = Mockery::mock(GetDivisionInfo::class);
         $mockInfo->data = [
@@ -212,7 +220,8 @@ class MemberSyncServiceTest extends TestCase
         ]);
     }
 
-    public function test_handles_zero_date_values(): void
+    #[Test]
+    public function handles_zero_date_values(): void
     {
         $division = Division::factory()->create();
 

--- a/tests/Unit/Services/RankTimelineServiceTest.php
+++ b/tests/Unit/Services/RankTimelineServiceTest.php
@@ -7,6 +7,7 @@ use App\Services\RankTimelineService;
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Collection;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Traits\CreatesDivisions;
 use Tests\Traits\CreatesMembers;
@@ -25,7 +26,8 @@ class RankTimelineServiceTest extends TestCase
         $this->service = new RankTimelineService;
     }
 
-    public function test_build_timeline_returns_object_with_required_properties()
+    #[Test]
+    public function build_timeline_returns_object_with_required_properties()
     {
         $division = $this->createActiveDivision();
         $member   = $this->createMember([
@@ -42,7 +44,8 @@ class RankTimelineServiceTest extends TestCase
         $this->assertObjectHasProperty('hasHistory', $result);
     }
 
-    public function test_build_timeline_has_history_is_true_when_join_date_exists()
+    #[Test]
+    public function build_timeline_has_history_is_true_when_join_date_exists()
     {
         $division = $this->createActiveDivision();
         $member   = $this->createMember([
@@ -56,7 +59,8 @@ class RankTimelineServiceTest extends TestCase
         $this->assertTrue($result->hasHistory);
     }
 
-    public function test_build_timeline_has_history_is_true_when_rank_history_exists()
+    #[Test]
+    public function build_timeline_has_history_is_true_when_rank_history_exists()
     {
         $division = $this->createActiveDivision();
         $member   = $this->createMember([
@@ -74,7 +78,8 @@ class RankTimelineServiceTest extends TestCase
         $this->assertTrue($result->hasHistory);
     }
 
-    public function test_build_timeline_has_history_is_false_when_no_history()
+    #[Test]
+    public function build_timeline_has_history_is_false_when_no_history()
     {
         $division = $this->createActiveDivision();
         $member   = $this->createMember([
@@ -88,7 +93,8 @@ class RankTimelineServiceTest extends TestCase
         $this->assertFalse($result->hasHistory);
     }
 
-    public function test_build_timeline_creates_join_node()
+    #[Test]
+    public function build_timeline_creates_join_node()
     {
         $division = $this->createActiveDivision();
         $joinDate = Carbon::now()->subYears(2);
@@ -106,7 +112,8 @@ class RankTimelineServiceTest extends TestCase
         $this->assertEquals($joinDate->format('M Y'), $joinNode->date);
     }
 
-    public function test_build_timeline_creates_promotion_nodes_for_rank_history()
+    #[Test]
+    public function build_timeline_creates_promotion_nodes_for_rank_history()
     {
         $division = $this->createActiveDivision();
         $member   = $this->createMember([
@@ -126,7 +133,8 @@ class RankTimelineServiceTest extends TestCase
         $this->assertGreaterThanOrEqual(1, $promotionNodes->count());
     }
 
-    public function test_build_timeline_filters_demotions_from_progression_nodes()
+    #[Test]
+    public function build_timeline_filters_demotions_from_progression_nodes()
     {
         $division = $this->createActiveDivision();
         $member   = $this->createMember([
@@ -148,7 +156,8 @@ class RankTimelineServiceTest extends TestCase
         $this->assertLessThan(4, $promotionNodes->count());
     }
 
-    public function test_build_timeline_history_items_include_demotions()
+    #[Test]
+    public function build_timeline_history_items_include_demotions()
     {
         $division = $this->createActiveDivision();
         $member   = $this->createMember([
@@ -168,7 +177,8 @@ class RankTimelineServiceTest extends TestCase
         $this->assertCount(1, $demotions);
     }
 
-    public function test_build_timeline_nodes_alternate_positions()
+    #[Test]
+    public function build_timeline_nodes_alternate_positions()
     {
         $division = $this->createActiveDivision();
         $member   = $this->createMember([
@@ -192,7 +202,8 @@ class RankTimelineServiceTest extends TestCase
         $this->assertEquals('right', $positions[3]);
     }
 
-    public function test_build_timeline_history_items_include_join_event()
+    #[Test]
+    public function build_timeline_history_items_include_join_event()
     {
         $division = $this->createActiveDivision();
         $joinDate = Carbon::now()->subYears(2);
@@ -209,7 +220,8 @@ class RankTimelineServiceTest extends TestCase
         $this->assertEquals($joinDate->format('M j, Y'), $joinItems->first()->date);
     }
 
-    public function test_build_timeline_returns_nodes_as_collection()
+    #[Test]
+    public function build_timeline_returns_nodes_as_collection()
     {
         $division = $this->createActiveDivision();
         $member   = $this->createMember([
@@ -223,7 +235,8 @@ class RankTimelineServiceTest extends TestCase
         $this->assertInstanceOf(Collection::class, $result->nodes);
     }
 
-    public function test_build_timeline_returns_history_items_as_collection()
+    #[Test]
+    public function build_timeline_returns_history_items_as_collection()
     {
         $division = $this->createActiveDivision();
         $member   = $this->createMember([
@@ -237,7 +250,8 @@ class RankTimelineServiceTest extends TestCase
         $this->assertInstanceOf(Collection::class, $result->historyItems);
     }
 
-    public function test_build_timeline_promotion_node_has_rank_abbreviation()
+    #[Test]
+    public function build_timeline_promotion_node_has_rank_abbreviation()
     {
         $division = $this->createActiveDivision();
         $member   = $this->createMember([
@@ -256,7 +270,8 @@ class RankTimelineServiceTest extends TestCase
         $this->assertEquals(Rank::CORPORAL->getAbbreviation(), $promotionNode->rank);
     }
 
-    public function test_build_timeline_history_items_orders_join_date_chronologically_with_retroactive_history()
+    #[Test]
+    public function build_timeline_history_items_orders_join_date_chronologically_with_retroactive_history()
     {
         $division = $this->createActiveDivision();
         $joinDate = Carbon::parse('2020-01-15');
@@ -282,7 +297,8 @@ class RankTimelineServiceTest extends TestCase
         $this->assertEquals('Jan 15, 2020', $joinItem->date);
     }
 
-    public function test_build_timeline_history_items_puts_join_first_when_before_all_history()
+    #[Test]
+    public function build_timeline_history_items_puts_join_first_when_before_all_history()
     {
         $division = $this->createActiveDivision();
         $joinDate = Carbon::parse('2005-01-01');
@@ -304,7 +320,8 @@ class RankTimelineServiceTest extends TestCase
         $this->assertEquals('Jan 1, 2005', $firstItem->date);
     }
 
-    public function test_build_timeline_history_items_puts_join_last_when_after_all_history()
+    #[Test]
+    public function build_timeline_history_items_puts_join_last_when_after_all_history()
     {
         $division = $this->createActiveDivision();
         $joinDate = Carbon::parse('2025-01-01');
@@ -326,7 +343,8 @@ class RankTimelineServiceTest extends TestCase
         $this->assertEquals('Jan 1, 2025', $lastItem->date);
     }
 
-    public function test_build_timeline_progression_includes_current_rank_even_if_below_historical_high()
+    #[Test]
+    public function build_timeline_progression_includes_current_rank_even_if_below_historical_high()
     {
         $division = $this->createActiveDivision();
         $member   = $this->createMember([

--- a/tests/Unit/Services/RecruitmentServiceTest.php
+++ b/tests/Unit/Services/RecruitmentServiceTest.php
@@ -6,6 +6,7 @@ use App\Models\Handle;
 use App\Models\Member;
 use App\Services\RecruitmentService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Traits\CreatesDivisions;
 
@@ -23,7 +24,8 @@ class RecruitmentServiceTest extends TestCase
         $this->service = new RecruitmentService;
     }
 
-    public function test_create_member_creates_new_member(): void
+    #[Test]
+    public function create_member_creates_new_member(): void
     {
         $division = $this->createActiveDivision();
         $platoon  = $this->createPlatoon($division);
@@ -47,7 +49,8 @@ class RecruitmentServiceTest extends TestCase
         ]);
     }
 
-    public function test_create_member_updates_existing_member(): void
+    #[Test]
+    public function create_member_updates_existing_member(): void
     {
         $division = $this->createActiveDivision();
         $platoon  = $this->createPlatoon($division);
@@ -72,7 +75,8 @@ class RecruitmentServiceTest extends TestCase
         $this->assertEquals('NewName', $member->fresh()->name);
     }
 
-    public function test_create_member_attaches_ingame_handle(): void
+    #[Test]
+    public function create_member_attaches_ingame_handle(): void
     {
         $division            = $this->createActiveDivision();
         $platoon             = $this->createPlatoon($division);
@@ -98,7 +102,8 @@ class RecruitmentServiceTest extends TestCase
         ]);
     }
 
-    public function test_create_member_request_creates_pending_request(): void
+    #[Test]
+    public function create_member_request_creates_pending_request(): void
     {
         $division = $this->createActiveDivision();
         $member   = Member::factory()->create(['division_id' => $division->id]);
@@ -112,7 +117,8 @@ class RecruitmentServiceTest extends TestCase
         ]);
     }
 
-    public function test_create_member_request_skips_if_pending_exists(): void
+    #[Test]
+    public function create_member_request_skips_if_pending_exists(): void
     {
         $division = $this->createActiveDivision();
         $member   = Member::factory()->create(['division_id' => $division->id]);

--- a/tests/Unit/Services/RecruitmentServiceTest.php
+++ b/tests/Unit/Services/RecruitmentServiceTest.php
@@ -106,7 +106,7 @@ class RecruitmentServiceTest extends TestCase
         $this->service->createMemberRequest($member, $division, 99999);
 
         $this->assertDatabaseHas('member_requests', [
-            'member_id'    => $member->clan_id,
+            'member_id'    => $member->id,
             'division_id'  => $division->id,
             'requester_id' => 99999,
         ]);

--- a/tests/Unit/Services/TicketNotificationServiceTest.php
+++ b/tests/Unit/Services/TicketNotificationServiceTest.php
@@ -16,6 +16,7 @@ use App\Services\TicketNotificationService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Queue;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Traits\CreatesDivisions;
 use Tests\Traits\CreatesMembers;
@@ -35,7 +36,8 @@ class TicketNotificationServiceTest extends TestCase
         Notification::fake();
     }
 
-    public function test_notify_ticket_created_sends_user_notification()
+    #[Test]
+    public function notify_ticket_created_sends_user_notification()
     {
         $user       = $this->createMemberWithUser();
         $ticketType = TicketType::factory()->create();
@@ -49,7 +51,8 @@ class TicketNotificationServiceTest extends TestCase
         Notification::assertSentTo($ticket, NotifyUserTicketCreated::class);
     }
 
-    public function test_notify_ticket_created_sends_admin_notification()
+    #[Test]
+    public function notify_ticket_created_sends_admin_notification()
     {
         $user       = $this->createMemberWithUser();
         $ticketType = TicketType::factory()->create();
@@ -63,7 +66,8 @@ class TicketNotificationServiceTest extends TestCase
         Notification::assertSentTo($ticket, NotifyAdminTicketCreated::class);
     }
 
-    public function test_notify_ticket_created_auto_assigns_when_ticket_type_has_auto_assign()
+    #[Test]
+    public function notify_ticket_created_auto_assigns_when_ticket_type_has_auto_assign()
     {
         $user       = $this->createMemberWithUser();
         $assignee   = $this->createAdmin();
@@ -86,7 +90,8 @@ class TicketNotificationServiceTest extends TestCase
         $this->assertEquals('assigned', $ticket->state);
     }
 
-    public function test_notify_ticket_created_dispatches_deferred_react_when_auto_assigned()
+    #[Test]
+    public function notify_ticket_created_dispatches_deferred_react_when_auto_assigned()
     {
         Queue::fake();
 
@@ -110,7 +115,8 @@ class TicketNotificationServiceTest extends TestCase
         Notification::assertNotSentTo($ticket, TicketReaction::class);
     }
 
-    public function test_notify_ticket_created_notifies_caller_when_auto_assigned()
+    #[Test]
+    public function notify_ticket_created_notifies_caller_when_auto_assigned()
     {
         $user       = $this->createMemberWithUser();
         $assignee   = $this->createAdmin();
@@ -131,7 +137,8 @@ class TicketNotificationServiceTest extends TestCase
         Notification::assertSentTo($ticket, NotifyCallerTicketUpdated::class);
     }
 
-    public function test_notify_ticket_created_notifies_new_owner_when_auto_assigned()
+    #[Test]
+    public function notify_ticket_created_notifies_new_owner_when_auto_assigned()
     {
         $user       = $this->createMemberWithUser();
         $assignee   = $this->createAdmin();
@@ -152,7 +159,8 @@ class TicketNotificationServiceTest extends TestCase
         Notification::assertSentTo($ticket, NotifyNewTicketOwner::class);
     }
 
-    public function test_notify_ticket_assigned_sends_caller_notification()
+    #[Test]
+    public function notify_ticket_assigned_sends_caller_notification()
     {
         $caller     = $this->createMemberWithUser();
         $assignee   = $this->createAdmin();
@@ -169,7 +177,8 @@ class TicketNotificationServiceTest extends TestCase
         Notification::assertSentTo($ticket, NotifyCallerTicketUpdated::class);
     }
 
-    public function test_notify_ticket_assigned_sends_owner_notification_when_assigned_by_another()
+    #[Test]
+    public function notify_ticket_assigned_sends_owner_notification_when_assigned_by_another()
     {
         $caller     = $this->createMemberWithUser();
         $assigner   = $this->createAdmin();
@@ -185,7 +194,8 @@ class TicketNotificationServiceTest extends TestCase
         Notification::assertSentTo($ticket, NotifyNewTicketOwner::class);
     }
 
-    public function test_notify_ticket_assigned_does_not_notify_owner_when_self_assigned()
+    #[Test]
+    public function notify_ticket_assigned_does_not_notify_owner_when_self_assigned()
     {
         $caller     = $this->createMemberWithUser();
         $assignee   = $this->createAdmin();
@@ -200,7 +210,8 @@ class TicketNotificationServiceTest extends TestCase
         Notification::assertNotSentTo($ticket, NotifyNewTicketOwner::class);
     }
 
-    public function test_notify_ticket_assigned_sends_reaction()
+    #[Test]
+    public function notify_ticket_assigned_sends_reaction()
     {
         $caller     = $this->createMemberWithUser();
         $assignee   = $this->createAdmin();
@@ -217,7 +228,8 @@ class TicketNotificationServiceTest extends TestCase
         Notification::assertSentTo($ticket, TicketReaction::class);
     }
 
-    public function test_notify_ticket_resolved_sends_reaction()
+    #[Test]
+    public function notify_ticket_resolved_sends_reaction()
     {
         $caller     = $this->createMemberWithUser();
         $ticketType = TicketType::factory()->create();
@@ -231,7 +243,8 @@ class TicketNotificationServiceTest extends TestCase
         Notification::assertSentTo($ticket, TicketReaction::class);
     }
 
-    public function test_notify_ticket_resolved_notifies_caller()
+    #[Test]
+    public function notify_ticket_resolved_notifies_caller()
     {
         $caller     = $this->createMemberWithUser();
         $ticketType = TicketType::factory()->create();
@@ -245,7 +258,8 @@ class TicketNotificationServiceTest extends TestCase
         Notification::assertSentTo($ticket, NotifyCallerTicketUpdated::class);
     }
 
-    public function test_notify_ticket_rejected_sends_reaction()
+    #[Test]
+    public function notify_ticket_rejected_sends_reaction()
     {
         $caller     = $this->createMemberWithUser();
         $ticketType = TicketType::factory()->create();
@@ -259,7 +273,8 @@ class TicketNotificationServiceTest extends TestCase
         Notification::assertSentTo($ticket, TicketReaction::class);
     }
 
-    public function test_notify_ticket_rejected_notifies_caller_with_reason()
+    #[Test]
+    public function notify_ticket_rejected_notifies_caller_with_reason()
     {
         $caller     = $this->createMemberWithUser();
         $ticketType = TicketType::factory()->create();
@@ -273,7 +288,8 @@ class TicketNotificationServiceTest extends TestCase
         Notification::assertSentTo($ticket, NotifyCallerTicketUpdated::class);
     }
 
-    public function test_notify_comment_added_does_not_notify_when_commenter_is_caller()
+    #[Test]
+    public function notify_comment_added_does_not_notify_when_commenter_is_caller()
     {
         $caller     = $this->createMemberWithUser();
         $ticketType = TicketType::factory()->create();
@@ -293,7 +309,8 @@ class TicketNotificationServiceTest extends TestCase
         Notification::assertNotSentTo($ticket, NotifyCallerTicketUpdated::class);
     }
 
-    public function test_notify_comment_added_notifies_caller_when_admin_comments()
+    #[Test]
+    public function notify_comment_added_notifies_caller_when_admin_comments()
     {
         $caller     = $this->createMemberWithUser();
         $admin      = $this->createAdmin();
@@ -314,7 +331,8 @@ class TicketNotificationServiceTest extends TestCase
         Notification::assertSentTo($ticket, NotifyCallerTicketUpdated::class);
     }
 
-    public function test_notify_comment_added_notifies_owner_when_caller_comments()
+    #[Test]
+    public function notify_comment_added_notifies_owner_when_caller_comments()
     {
         $caller     = $this->createMemberWithUser();
         $owner      = $this->createAdmin();
@@ -336,7 +354,8 @@ class TicketNotificationServiceTest extends TestCase
         Notification::assertSentTo($ticket, NotifyAdminTicketUpdated::class);
     }
 
-    public function test_notify_comment_added_does_not_notify_owner_when_owner_comments()
+    #[Test]
+    public function notify_comment_added_does_not_notify_owner_when_owner_comments()
     {
         $caller     = $this->createMemberWithUser();
         $owner      = $this->createAdmin();
@@ -358,7 +377,8 @@ class TicketNotificationServiceTest extends TestCase
         Notification::assertNotSentTo($ticket, NotifyAdminTicketUpdated::class);
     }
 
-    public function test_notify_new_ticket_owner_uses_discord_id_in_bot_payload()
+    #[Test]
+    public function notify_new_ticket_owner_uses_discord_id_in_bot_payload()
     {
         $owner      = $this->createMemberWithUser();
         $ticketType = TicketType::factory()->create();
@@ -376,7 +396,8 @@ class TicketNotificationServiceTest extends TestCase
         $this->assertStringNotContainsString('someusername', $payload['api_uri']);
     }
 
-    public function test_notify_user_ticket_created_uses_discord_id_in_bot_payload()
+    #[Test]
+    public function notify_user_ticket_created_uses_discord_id_in_bot_payload()
     {
         $caller     = $this->createMemberWithUser();
         $ticketType = TicketType::factory()->create();
@@ -395,7 +416,8 @@ class TicketNotificationServiceTest extends TestCase
         $this->assertStringNotContainsString('someusername', $payload['api_uri']);
     }
 
-    public function test_notify_caller_ticket_updated_uses_discord_id_in_bot_payload()
+    #[Test]
+    public function notify_caller_ticket_updated_uses_discord_id_in_bot_payload()
     {
         $caller     = $this->createMemberWithUser();
         $ticketType = TicketType::factory()->create();


### PR DESCRIPTION
We have had inconsistent usage of clan id and tracker member id for many years. This work attempts to resolve those inconsistencies except in a few specific cases where we want to enable convenient references IE searching for a member or viewing a member profile.