### PR TITLE
Exclude Trainer's Tr prefix from rank abbreviation validation

### DIFF
--- a/app/Http/Requests/Auth/DiscordRegistrationRequest.php
+++ b/app/Http/Requests/Auth/DiscordRegistrationRequest.php
@@ -33,6 +33,12 @@ class DiscordRegistrationRequest extends FormRequest
 
                     $lower = strtolower($value);
                     foreach (Rank::cases() as $rank) {
+                        // Trainer's "Tr" abbreviation is excluded: it's a common name
+                        // prefix (Travis, Trent, etc.) rather than a recognizable rank.
+                        if ($rank === Rank::TRAINER) {
+                            continue;
+                        }
+
                         if (str_starts_with($lower, strtolower($rank->getAbbreviation()))) {
                             $fail('Username cannot begin with a rank abbreviation.');
 

--- a/tests/Unit/Requests/DiscordRegistrationRequestTest.php
+++ b/tests/Unit/Requests/DiscordRegistrationRequestTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Unit\Requests;
+
+use App\Http\Requests\Auth\DiscordRegistrationRequest;
+use Illuminate\Contracts\Validation\Validator as ValidatorContract;
+use Illuminate\Support\Facades\Validator;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class DiscordRegistrationRequestTest extends TestCase
+{
+    private function validateUsername(string $username): ValidatorContract
+    {
+        $request = DiscordRegistrationRequest::create('/register', 'POST', [
+            'username'    => $username,
+            'division_id' => null,
+        ]);
+
+        return Validator::make($request->all(), $request->rules());
+    }
+
+    #[Test]
+    public function username_starting_with_tr_is_allowed()
+    {
+        $validator = $this->validateUsername('Travis');
+
+        $this->assertFalse($validator->errors()->has('username'));
+    }
+
+    #[Test]
+    public function username_starting_with_other_rank_abbreviation_is_rejected()
+    {
+        $validator = $this->validateUsername('Sgtfoobar');
+
+        $this->assertTrue($validator->errors()->has('username'));
+        $this->assertStringContainsString('rank abbreviation', $validator->errors()->first('username'));
+    }
+
+    #[Test]
+    public function username_starting_with_aod_prefix_is_still_rejected()
+    {
+        $validator = $this->validateUsername('AOD_something');
+
+        $this->assertTrue($validator->errors()->has('username'));
+        $this->assertStringContainsString('AOD_', $validator->errors()->first('username'));
+    }
+}

--- a/tests/Unit/Requests/DiscordRegistrationRequestTest.php
+++ b/tests/Unit/Requests/DiscordRegistrationRequestTest.php
@@ -4,12 +4,15 @@ namespace Tests\Unit\Requests;
 
 use App\Http\Requests\Auth\DiscordRegistrationRequest;
 use Illuminate\Contracts\Validation\Validator as ValidatorContract;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Validator;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class DiscordRegistrationRequestTest extends TestCase
 {
+    use RefreshDatabase;
+
     private function validateUsername(string $username): ValidatorContract
     {
         $request = DiscordRegistrationRequest::create('/register', 'POST', [


### PR DESCRIPTION
Tr is a common name prefix (Travis, Trent, etc.) rather than a recognizable rank abbreviation in context, unlike the other rank prefixes this validation guards against.