### PR TITLE
Add fallen members admin resource and API endpoint

### DIFF
--- a/app/Filament/Admin/Resources/FallenMemberResource.php
+++ b/app/Filament/Admin/Resources/FallenMemberResource.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Filament\Admin\Resources;
+
+use App\Filament\Admin\Resources\FallenMemberResource\Pages\CreateFallenMember;
+use App\Filament\Admin\Resources\FallenMemberResource\Pages\EditFallenMember;
+use App\Filament\Admin\Resources\FallenMemberResource\Pages\ListFallenMembers;
+use App\Models\FallenMember;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Columns\TextInputColumn;
+use Filament\Tables\Table;
+
+class FallenMemberResource extends Resource
+{
+    protected static ?string $model = FallenMember::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-heart';
+
+    protected static string|\UnitEnum|null $navigationGroup = 'Members';
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema
+            ->columns(1)
+            ->components([
+                TextInput::make('name')
+                    ->required()
+                    ->maxLength(191),
+                Select::make('member_id')
+                    ->relationship('member', 'name')
+                    ->label('Linked Member')
+                    ->helperText('Optional — leave blank if the member record no longer exists')
+                    ->searchable()
+                    ->nullable(),
+                DatePicker::make('date_fallen')
+                    ->nullable(),
+                TextInput::make('forum_profile')
+                    ->label('Forum Profile URL')
+                    ->url()
+                    ->maxLength(255)
+                    ->nullable(),
+                TextInput::make('display_order')
+                    ->required()
+                    ->numeric()
+                    ->default(100),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('name')
+                    ->sortable()
+                    ->searchable(),
+                TextColumn::make('member.name')
+                    ->label('Linked Member')
+                    ->placeholder('—')
+                    ->toggleable(isToggledHiddenByDefault: true),
+                TextColumn::make('date_fallen')
+                    ->date()
+                    ->placeholder('Unknown')
+                    ->sortable(),
+                TextInputColumn::make('display_order')
+                    ->rules(['required', 'numeric'])
+                    ->sortable()
+                    ->width('80px'),
+            ])
+            ->defaultSort('display_order')
+            ->recordActions([
+                EditAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index'  => ListFallenMembers::route('/'),
+            'create' => CreateFallenMember::route('/create'),
+            'edit'   => EditFallenMember::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/FallenMemberResource/Pages/CreateFallenMember.php
+++ b/app/Filament/Admin/Resources/FallenMemberResource/Pages/CreateFallenMember.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Admin\Resources\FallenMemberResource\Pages;
+
+use App\Filament\Admin\Resources\FallenMemberResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateFallenMember extends CreateRecord
+{
+    protected static string $resource = FallenMemberResource::class;
+}

--- a/app/Filament/Admin/Resources/FallenMemberResource/Pages/EditFallenMember.php
+++ b/app/Filament/Admin/Resources/FallenMemberResource/Pages/EditFallenMember.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Admin\Resources\FallenMemberResource\Pages;
+
+use App\Filament\Admin\Resources\FallenMemberResource;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditFallenMember extends EditRecord
+{
+    protected static string $resource = FallenMemberResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/FallenMemberResource/Pages/ListFallenMembers.php
+++ b/app/Filament/Admin/Resources/FallenMemberResource/Pages/ListFallenMembers.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Admin\Resources\FallenMemberResource\Pages;
+
+use App\Filament\Admin\Resources\FallenMemberResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListFallenMembers extends ListRecords
+{
+    protected static string $resource = FallenMemberResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Http/Controllers/API/v1/FallenMemberController.php
+++ b/app/Http/Controllers/API/v1/FallenMemberController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers\API\v1;
+
+use App\Models\FallenMember;
+use App\Transformers\FallenMemberTransformer;
+use Illuminate\Http\JsonResponse;
+
+class FallenMemberController extends ApiController
+{
+    public function __construct(private readonly FallenMemberTransformer $transformer) {}
+
+    public function index(): JsonResponse
+    {
+        $fallenMembers = FallenMember::orderBy('display_order')->get();
+
+        return $this->respond([
+            'data' => $this->transformer->transformCollection($fallenMembers->all()),
+        ]);
+    }
+}

--- a/app/Models/FallenMember.php
+++ b/app/Models/FallenMember.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class FallenMember extends Model
+{
+    use HasFactory;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'date_fallen' => 'date',
+    ];
+
+    public function member(): BelongsTo
+    {
+        return $this->belongsTo(Member::class);
+    }
+}

--- a/app/Transformers/FallenMemberTransformer.php
+++ b/app/Transformers/FallenMemberTransformer.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Transformers;
+
+class FallenMemberTransformer extends Transformer
+{
+    public function transform($item): array
+    {
+        return [
+            'name'          => $item->name,
+            'date_fallen'   => $item->date_fallen?->format('m/d/Y') ?? 'Unknown',
+            'forum_profile' => $item->forum_profile,
+        ];
+    }
+}

--- a/database/migrations/2026_08_11_223000_create_fallen_members_table.php
+++ b/database/migrations/2026_08_11_223000_create_fallen_members_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('fallen_members', function (Blueprint $table) {
+            $table->id();
+            $table->string('name', 191);
+            $table->unsignedInteger('member_id')->nullable();
+            $table->date('date_fallen')->nullable();
+            $table->string('forum_profile')->nullable();
+            $table->integer('display_order')->default(100);
+            $table->timestamps();
+
+            $table->foreign('member_id')->references('id')->on('members')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('fallen_members');
+    }
+};

--- a/database/migrations/2026_08_11_223500_seed_existing_fallen_members.php
+++ b/database/migrations/2026_08_11_223500_seed_existing_fallen_members.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    private array $fallenMembers = [
+        ['name' => 'Kevin "Bluntz" Lovelace', 'date_fallen' => '2021-11-14', 'forum_profile' => 'https://www.clanaod.net/forums/member.php?u=3419'],
+        ['name' => 'AchesAndPains', 'date_fallen' => '2020-07-17', 'forum_profile' => 'https://www.clanaod.net/forums/member.php?u=33030'],
+        ['name' => 'Bruce "hailhydra2018" Kennedy', 'date_fallen' => '2020-01-18', 'forum_profile' => 'https://www.clanaod.net/forums/member.php?u=62669'],
+        ['name' => 'MD9445', 'date_fallen' => null, 'forum_profile' => 'https://www.clanaod.net/forums/member.php?u=20244'],
+        ['name' => 'Quake-id', 'date_fallen' => null, 'forum_profile' => 'https://www.clanaod.net/forums/member.php?u=56057'],
+        ['name' => 'Lance "Syph3n" Groth', 'date_fallen' => '2015-01-12', 'forum_profile' => 'https://www.clanaod.net/forums/member.php?u=26433'],
+        ['name' => 'oc675', 'date_fallen' => '2015-11-08', 'forum_profile' => 'https://www.clanaod.net/forums/member.php?u=35067'],
+        ['name' => 'Pafire', 'date_fallen' => '2020-11-05', 'forum_profile' => 'https://www.clanaod.net/forums/member.php?u=51680'],
+        ['name' => 'William "T Dooly" McCoy', 'date_fallen' => '2023-07-22', 'forum_profile' => 'https://www.clanaod.net/forums/member.php?u=49952'],
+        ['name' => 'Stefan "Drakooth" Erfmann', 'date_fallen' => '2024-03-04', 'forum_profile' => 'https://www.clanaod.net/forums/member.php?u=85302'],
+    ];
+
+    public function up(): void
+    {
+        $now = now();
+
+        foreach ($this->fallenMembers as $index => $fallenMember) {
+            DB::table('fallen_members')->insert([
+                ...$fallenMember,
+                'display_order' => ($index + 1) * 10,
+                'created_at'    => $now,
+                'updated_at'    => $now,
+            ]);
+        }
+    }
+
+    public function down(): void
+    {
+        DB::table('fallen_members')
+            ->whereIn('forum_profile', array_column($this->fallenMembers, 'forum_profile'))
+            ->delete();
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -4,12 +4,17 @@ use App\Http\Controllers\API\DivisionApplicationApiController;
 use App\Http\Controllers\API\TicketApiController;
 use App\Http\Controllers\API\v1\ClanController;
 use App\Http\Controllers\API\v1\DivisionController;
+use App\Http\Controllers\API\v1\FallenMemberController;
 use Illuminate\Support\Facades\Route;
 
 Route::prefix('v1')->name('v1.')->group(function () {
     Route::controller(ClanController::class)->middleware('abilities:clan:read')->group(function () {
         Route::get('discord-count', 'discordPopulationCount')->name('discord_population');
         Route::get('stream-events', 'streamEvents')->name('stream_events');
+    });
+
+    Route::controller(FallenMemberController::class)->middleware('abilities:clan:read')->group(function () {
+        Route::get('fallen-members', 'index')->name('fallen_members');
     });
 
     Route::controller(DivisionController::class)->prefix('divisions')->name('divisions.')->group(function () {


### PR DESCRIPTION
## Summary
- New `fallen_members` table (name, optional `member_id` link, `date_fallen`, `forum_profile`, `display_order`) plus a one-time migration seeding the 10 entries currently hardcoded in aod_site_v2's config.
- `FallenMember` model and a Filament admin resource (Members nav group) for managing entries going forward.
- `GET /api/v1/fallen-members`, reusing the existing `clan:read` Sanctum ability so aod_site_v2's current token works without reissuing.

This lets the "fallen angels" memorial list be managed in tracker instead of a static config array in aod_site_v2. Companion PR on aod_site_v2 switches its `FallenAngelsController` to consume this endpoint.

## Test plan
- [x] `sail artisan test` passes (896 passed, 4 skipped)
- [x] `./vendor/bin/pint --test` passes
- [x] Verified `GET /api/v1/fallen-members` end-to-end with a real token, output matches transformer shape