### PR TITLE
Move Discord Info action to Edit Member page

### DIFF
--- a/app/Filament/Mod/Resources/MemberResource.php
+++ b/app/Filament/Mod/Resources/MemberResource.php
@@ -17,7 +17,6 @@ use App\Models\DivisionTag;
 use App\Models\Member;
 use App\Models\Platoon;
 use App\Models\Squad;
-use App\Services\ForumProcedureService;
 use Filament\Actions\Action;
 use Filament\Actions\BulkAction;
 use Filament\Actions\BulkActionGroup;
@@ -420,39 +419,6 @@ class MemberResource extends Resource
 
                         Notification::make()
                             ->title('Handles updated')
-                            ->success()
-                            ->send();
-                    }),
-                Action::make('setDiscordInfo')
-                    ->label('Discord Info')
-                    ->icon('heroicon-o-chat-bubble-left-right')
-                    ->visible(fn (Member $record): bool => auth()->user()->can('update', $record))
-                    ->fillForm(fn (Member $record): array => [
-                        'discord_id'  => $record->discord_id,
-                        'discord_tag' => $record->discord,
-                    ])
-                    ->form([
-                        TextInput::make('discord_id')
-                            ->label('Discord User ID')
-                            ->rule('regex:/^\d+$/')
-                            ->nullable(),
-                        TextInput::make('discord_tag')
-                            ->label('Discord Username/Tag')
-                            ->nullable(),
-                    ])
-                    ->action(function (Member $record, array $data, ForumProcedureService $forumProcedureService): void {
-                        $discordId  = (string) ($data['discord_id'] ?? '');
-                        $discordTag = (string) ($data['discord_tag'] ?? '');
-
-                        $forumProcedureService->setDiscordInfo($record->clan_id, $discordId, $discordTag);
-
-                        $record->update([
-                            'discord_id' => $discordId !== '' ? $discordId : null,
-                            'discord'    => $discordTag !== '' ? $discordTag : null,
-                        ]);
-
-                        Notification::make()
-                            ->title('Discord info updated')
                             ->success()
                             ->send();
                     }),

--- a/app/Filament/Mod/Resources/MemberResource/Pages/EditMember.php
+++ b/app/Filament/Mod/Resources/MemberResource/Pages/EditMember.php
@@ -13,9 +13,11 @@ use App\Models\Note;
 use App\Notifications\Channel\NotifyDivisionMemberRemoved;
 use App\Notifications\Channel\NotifyDivisionPartTimeMemberRemoved;
 use App\Services\AODForumService;
+use App\Services\ForumProcedureService;
 use Filament\Actions\Action;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\EditRecord;
 use Illuminate\Database\Eloquent\Model;
@@ -72,6 +74,40 @@ class EditMember extends EditRecord
                 ->icon('heroicon-o-eye')
                 ->url(fn ($record) => route('member', $record->getUrlParams()))
                 ->openUrlInNewTab(),
+
+            Action::make('setDiscordInfo')
+                ->label('Discord Info')
+                ->icon('heroicon-o-chat-bubble-left-right')
+                ->visible(fn (): bool => auth()->user()->can('update', $this->record))
+                ->fillForm(fn (): array => [
+                    'discord_id'  => $this->record->discord_id,
+                    'discord_tag' => $this->record->discord,
+                ])
+                ->schema([
+                    TextInput::make('discord_id')
+                        ->label('Discord User ID')
+                        ->rule('regex:/^\d+$/')
+                        ->nullable(),
+                    TextInput::make('discord_tag')
+                        ->label('Discord Username/Tag')
+                        ->nullable(),
+                ])
+                ->action(function (array $data, ForumProcedureService $forumProcedureService): void {
+                    $discordId  = (string) ($data['discord_id'] ?? '');
+                    $discordTag = (string) ($data['discord_tag'] ?? '');
+
+                    $forumProcedureService->setDiscordInfo($this->record->clan_id, $discordId, $discordTag);
+
+                    $this->record->update([
+                        'discord_id' => $discordId !== '' ? $discordId : null,
+                        'discord'    => $discordTag !== '' ? $discordTag : null,
+                    ]);
+
+                    Notification::make()
+                        ->title('Discord info updated')
+                        ->success()
+                        ->send();
+                }),
 
             Action::make('remove_member')
                 ->label('Remove Member')

--- a/tests/Feature/Filament/MemberResourceSetDiscordInfoTest.php
+++ b/tests/Feature/Filament/MemberResourceSetDiscordInfoTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Feature\Filament;
 
-use App\Filament\Mod\Resources\MemberResource\Pages\ListMembers;
+use App\Filament\Mod\Resources\MemberResource\Pages\EditMember;
 use App\Services\ForumProcedureService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Livewire;
@@ -33,12 +33,12 @@ class MemberResourceSetDiscordInfoTest extends TestCase
 
         $this->actingAs($srLdr);
 
-        Livewire::test(ListMembers::class)
-            ->callTableAction('setDiscordInfo', $member, data: [
+        Livewire::test(EditMember::class, ['record' => $member->getRouteKey()])
+            ->callAction('setDiscordInfo', data: [
                 'discord_id'  => '123456789012345678',
                 'discord_tag' => 'newusername',
             ])
-            ->assertHasNoTableActionErrors();
+            ->assertHasNoActionErrors();
 
         $member->refresh();
         $this->assertSame('123456789012345678', $member->discord_id);
@@ -54,24 +54,23 @@ class MemberResourceSetDiscordInfoTest extends TestCase
 
         $this->actingAs($srLdr);
 
-        Livewire::test(ListMembers::class)
-            ->callTableAction('setDiscordInfo', $member, data: [
+        Livewire::test(EditMember::class, ['record' => $member->getRouteKey()])
+            ->callAction('setDiscordInfo', data: [
                 'discord_id'  => 'not-a-snowflake',
                 'discord_tag' => 'someuser',
             ])
-            ->assertHasTableActionErrors(['discord_id']);
+            ->assertHasActionErrors(['discord_id']);
     }
 
     #[Test]
-    public function member_role_cannot_see_set_discord_info_action(): void
+    public function member_role_cannot_reach_the_edit_page_at_all(): void
     {
         $division = $this->createActiveDivision();
         $user     = $this->createMemberWithUser(['division_id' => $division->id]);
         $member   = $this->createMember(['division_id' => $division->id]);
 
-        $this->actingAs($user);
-
-        Livewire::test(ListMembers::class)
-            ->assertTableActionHidden('setDiscordInfo', $member);
+        $this->actingAs($user)
+            ->get(route('filament.mod.resources.members.edit', $member))
+            ->assertForbidden();
     }
 }


### PR DESCRIPTION
## Summary
- Relocates the "Discord Info" action (added last release) from a row action on the Operations member list to a header action on the Edit Member page only, alongside View Profile and Remove Member.
- Uses the same `ForumProcedureService::setDiscordInfo()` call and local-record sync as before, just gated by the same `update` ability the edit page itself already requires — reachable only from a member's edit screen now.

## Test plan
- [x] Full suite passes (955 passed)
- [x] `./vendor/bin/pint --test` passes
- [x] Verified live against dev data that the action renders on the Edit Member page for a qualifying sr_ldr