### PR TITLE
Restrict Discord Info action to clearing only

### DIFF
--- a/app/Filament/Mod/Resources/MemberResource/Pages/EditMember.php
+++ b/app/Filament/Mod/Resources/MemberResource/Pages/EditMember.php
@@ -17,7 +17,6 @@ use App\Services\ForumProcedureService;
 use Filament\Actions\Action;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
-use Filament\Forms\Components\TextInput;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\EditRecord;
 use Illuminate\Database\Eloquent\Model;
@@ -76,35 +75,22 @@ class EditMember extends EditRecord
                 ->openUrlInNewTab(),
 
             Action::make('setDiscordInfo')
-                ->label('Discord Info')
-                ->icon('heroicon-o-chat-bubble-left-right')
+                ->label('Clear Discord Info')
+                ->icon('heroicon-o-x-circle')
+                ->color('danger')
                 ->visible(fn (): bool => auth()->user()->can('update', $this->record))
-                ->fillForm(fn (): array => [
-                    'discord_id'  => $this->record->discord_id,
-                    'discord_tag' => $this->record->discord,
-                ])
-                ->schema([
-                    TextInput::make('discord_id')
-                        ->label('Discord User ID')
-                        ->rule('regex:/^\d+$/')
-                        ->nullable(),
-                    TextInput::make('discord_tag')
-                        ->label('Discord Username/Tag')
-                        ->nullable(),
-                ])
-                ->action(function (array $data, ForumProcedureService $forumProcedureService): void {
-                    $discordId  = (string) ($data['discord_id'] ?? '');
-                    $discordTag = (string) ($data['discord_tag'] ?? '');
-
-                    $forumProcedureService->setDiscordInfo($this->record->clan_id, $discordId, $discordTag);
+                ->requiresConfirmation()
+                ->modalDescription('This will remove the Discord account link for this member on both the forum and the tracker.')
+                ->action(function (ForumProcedureService $forumProcedureService): void {
+                    $forumProcedureService->clearDiscordInfo($this->record->clan_id);
 
                     $this->record->update([
-                        'discord_id' => $discordId !== '' ? $discordId : null,
-                        'discord'    => $discordTag !== '' ? $discordTag : null,
+                        'discord_id' => null,
+                        'discord'    => null,
                     ]);
 
                     Notification::make()
-                        ->title('Discord info updated')
+                        ->title('Discord info cleared')
                         ->success()
                         ->send();
                 }),

--- a/tests/Feature/Filament/MemberResourceSetDiscordInfoTest.php
+++ b/tests/Feature/Filament/MemberResourceSetDiscordInfoTest.php
@@ -18,48 +18,32 @@ class MemberResourceSetDiscordInfoTest extends TestCase
     use RefreshDatabase;
 
     #[Test]
-    public function sr_ldr_can_set_discord_info(): void
+    public function sr_ldr_can_clear_discord_info(): void
     {
         $division = $this->createActiveDivision();
         $srLdr    = $this->createSeniorLeader($division);
-        $member   = $this->createMember(['division_id' => $division->id, 'discord_id' => null, 'discord' => null]);
+        $member   = $this->createMember([
+            'division_id' => $division->id,
+            'discord_id'  => '123456789012345678',
+            'discord'     => 'existingusername',
+        ]);
 
         $this->mock(ForumProcedureService::class, function ($mock) use ($member) {
-            $mock->shouldReceive('setDiscordInfo')
+            $mock->shouldReceive('clearDiscordInfo')
                 ->once()
-                ->with($member->clan_id, '123456789012345678', 'newusername')
+                ->with($member->clan_id)
                 ->andReturn(null);
         });
 
         $this->actingAs($srLdr);
 
         Livewire::test(EditMember::class, ['record' => $member->getRouteKey()])
-            ->callAction('setDiscordInfo', data: [
-                'discord_id'  => '123456789012345678',
-                'discord_tag' => 'newusername',
-            ])
+            ->callAction('setDiscordInfo')
             ->assertHasNoActionErrors();
 
         $member->refresh();
-        $this->assertSame('123456789012345678', $member->discord_id);
-        $this->assertSame('newusername', $member->discord);
-    }
-
-    #[Test]
-    public function discord_id_must_be_numeric(): void
-    {
-        $division = $this->createActiveDivision();
-        $srLdr    = $this->createSeniorLeader($division);
-        $member   = $this->createMember(['division_id' => $division->id]);
-
-        $this->actingAs($srLdr);
-
-        Livewire::test(EditMember::class, ['record' => $member->getRouteKey()])
-            ->callAction('setDiscordInfo', data: [
-                'discord_id'  => 'not-a-snowflake',
-                'discord_tag' => 'someuser',
-            ])
-            ->assertHasActionErrors(['discord_id']);
+        $this->assertNull($member->discord_id);
+        $this->assertNull($member->discord);
     }
 
     #[Test]


### PR DESCRIPTION
Setting arbitrary discord_id/discord_tag values on the Discord
Info action let officers link a member to any Discord account,
which is a security risk. The `setDiscordInfo` header action on
`EditMember` now only clears the existing link via
`ForumProcedureService::clearDiscordInfo()`, both on the forum
and locally.