### PR TITLE
Scope Discord clear action to forum only

### DIFF
--- a/app/Filament/Mod/Resources/MemberResource/Pages/EditMember.php
+++ b/app/Filament/Mod/Resources/MemberResource/Pages/EditMember.php
@@ -75,22 +75,17 @@ class EditMember extends EditRecord
                 ->openUrlInNewTab(),
 
             Action::make('setDiscordInfo')
-                ->label('Clear Discord Info')
+                ->label('Clear Forum Discord Info')
                 ->icon('heroicon-o-x-circle')
                 ->color('danger')
                 ->visible(fn (): bool => auth()->user()->can('update', $this->record))
                 ->requiresConfirmation()
-                ->modalDescription('This will remove the Discord account link for this member on both the forum and the tracker.')
+                ->modalDescription('This will remove the Discord account link on the forum, allowing the member to link their currently authenticated Discord account.')
                 ->action(function (ForumProcedureService $forumProcedureService): void {
                     $forumProcedureService->clearDiscordInfo($this->record->clan_id);
 
-                    $this->record->update([
-                        'discord_id' => null,
-                        'discord'    => null,
-                    ]);
-
                     Notification::make()
-                        ->title('Discord info cleared')
+                        ->title('Forum Discord info cleared')
                         ->success()
                         ->send();
                 }),

--- a/tests/Feature/Filament/MemberResourceSetDiscordInfoTest.php
+++ b/tests/Feature/Filament/MemberResourceSetDiscordInfoTest.php
@@ -18,7 +18,7 @@ class MemberResourceSetDiscordInfoTest extends TestCase
     use RefreshDatabase;
 
     #[Test]
-    public function sr_ldr_can_clear_discord_info(): void
+    public function sr_ldr_can_clear_forum_discord_info(): void
     {
         $division = $this->createActiveDivision();
         $srLdr    = $this->createSeniorLeader($division);
@@ -42,8 +42,8 @@ class MemberResourceSetDiscordInfoTest extends TestCase
             ->assertHasNoActionErrors();
 
         $member->refresh();
-        $this->assertNull($member->discord_id);
-        $this->assertNull($member->discord);
+        $this->assertSame('123456789012345678', $member->discord_id);
+        $this->assertSame('existingusername', $member->discord);
     }
 
     #[Test]


### PR DESCRIPTION
Clearing was also nulling the local `discord_id`/`discord`
fields on the `Member` model, but the action exists so an
officer can clear the forum-side link and let a member relink
their currently authenticated Discord account. The local fields
need to stay intact for that to work, so `setDiscordInfo` on
`EditMember` now only calls
`ForumProcedureService::clearDiscordInfo()`.