### PR TITLE
Add completion button for deep-linked training

### DIFF
--- a/resources/views/member/partials/member-actions-button.blade.php
+++ b/resources/views/member/partials/member-actions-button.blade.php
@@ -10,9 +10,11 @@
             </li>
 
             @can('train', auth()->user())
-                <li>
-                    <a href="{{ route('training.sgt', ['clan_id' => $member->clan_id]) }}">SGT Training</a>
-                </li>
+                @if ($member->rank->isAtLeast(\App\Enums\Rank::SERGEANT))
+                    <li>
+                        <a href="{{ route('training.sgt', ['clan_id' => $member->clan_id]) }}">SGT Training</a>
+                    </li>
+                @endif
             @endcan
 
 @if ($member->user)

--- a/resources/views/training/module.blade.php
+++ b/resources/views/training/module.blade.php
@@ -141,36 +141,45 @@
             </div>
         </div>
 
-        @if(request()->has('training') && $module->show_completion_form)
+        @if($trainee && $module->show_completion_form)
             <div class="training-stepper__completion">
                 <div class="panel panel-filled panel-c-success">
                     <div class="panel-heading">
                         <i class="fa fa-check-circle"></i> Complete Training
                     </div>
                     <div class="panel-body">
-                        <p>Once you are finished with the training session, search for the member
-                            you are training and submit.</p>
+                        <p>Mark this training session complete for <strong>{{ $trainee->name }}</strong>?</p>
                         <p class="text-muted m-b-none">This will update the member's last training date and set you as the trainer.</p>
                     </div>
                     <div class="panel-footer">
-                        <form action="{{ route('training.update') }}" method="POST" class="training-stepper__form">
+                        <button type="button" class="btn btn-success" data-toggle="modal" data-target="#complete-training-modal">
+                            <i class="fa fa-check"></i> Mark Training Complete
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            <div class="modal fade" id="complete-training-modal" tabindex="-1" role="dialog" aria-labelledby="complete-training-modal-title">
+                <div class="modal-dialog" role="document">
+                    <div class="modal-content">
+                        <form action="{{ route('training.update') }}" method="POST">
                             @csrf
                             <input type="hidden" name="module" value="{{ $module->slug }}">
-                            <div class="training-stepper__form-row">
-                                <div class="input-group">
-                                    <span class="input-group-addon"><i class="fa fa-user"></i></span>
-                                    <input type="text"
-                                           class="form-control search-member"
-                                           id="trainee_name"
-                                           name="trainee_name"
-                                           autocomplete="off"
-                                           placeholder="Search for member..."
-                                           value="{{ $trainee?->name }}"
-                                    />
-                                </div>
-                                <input type="hidden" name="clan_id" id="clan_id" value="{{ $trainee?->clan_id }}">
+                            <input type="hidden" name="clan_id" value="{{ $trainee->clan_id }}">
+                            <div class="modal-header">
+                                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                    <span aria-hidden="true">&times;</span>
+                                </button>
+                                <h4 class="modal-title" id="complete-training-modal-title">Confirm Training Completion</h4>
+                            </div>
+                            <div class="modal-body">
+                                <p>Mark <strong>{{ $trainee->name }}</strong> as having completed the {{ $module->name }} training?</p>
+                                <p class="text-muted">This sets their last training date to now and records you as the trainer.</p>
+                            </div>
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
                                 <button type="submit" class="btn btn-success">
-                                    <i class="fa fa-check"></i> Complete Training
+                                    <i class="fa fa-check"></i> Confirm
                                 </button>
                             </div>
                         </form>

--- a/tests/Feature/Controllers/MemberActionsButtonTest.php
+++ b/tests/Feature/Controllers/MemberActionsButtonTest.php
@@ -19,13 +19,25 @@ class MemberActionsButtonTest extends TestCase
     public function sgt_training_link_is_visible_for_qualifying_sr_ldr()
     {
         $srLdr  = $this->createSeniorLeader(memberAttributes: ['rank' => Rank::STAFF_SERGEANT]);
-        $member = $this->createMember();
+        $member = $this->createMember(['rank' => Rank::SERGEANT]);
 
         $this->actingAs($srLdr)
             ->get(route('member', $member->getUrlParams()))
             ->assertOk()
             ->assertSee(route('training.sgt', ['clan_id' => $member->clan_id]), false)
             ->assertSee('SGT Training');
+    }
+
+    #[Test]
+    public function sgt_training_link_is_hidden_for_member_below_sergeant()
+    {
+        $srLdr  = $this->createSeniorLeader(memberAttributes: ['rank' => Rank::STAFF_SERGEANT]);
+        $member = $this->createMember(['rank' => Rank::CORPORAL]);
+
+        $this->actingAs($srLdr)
+            ->get(route('member', $member->getUrlParams()))
+            ->assertOk()
+            ->assertDontSee('SGT Training');
     }
 
     #[Test]

--- a/tests/Feature/Controllers/TrainingModuleCompletionTest.php
+++ b/tests/Feature/Controllers/TrainingModuleCompletionTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Tests\Feature\Controllers;
+
+use App\Enums\Rank;
+use App\Models\TrainingModule;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+use Tests\Traits\CreatesDivisions;
+use Tests\Traits\CreatesMembers;
+
+class TrainingModuleCompletionTest extends TestCase
+{
+    use CreatesDivisions;
+    use CreatesMembers;
+    use RefreshDatabase;
+
+    #[Test]
+    public function completion_button_shows_for_deep_linked_trainee(): void
+    {
+        $srLdr  = $this->createSeniorLeader(memberAttributes: ['rank' => Rank::STAFF_SERGEANT]);
+        $module = TrainingModule::create([
+            'name'                 => 'General Training',
+            'slug'                 => 'general',
+            'is_active'            => true,
+            'show_completion_form' => true,
+        ]);
+        $trainee = $this->createMember();
+
+        $this->actingAs($srLdr)
+            ->get(route('training.show', ['slug' => $module->slug, 'clan_id' => $trainee->clan_id]))
+            ->assertOk()
+            ->assertSee('Mark Training Complete')
+            ->assertSee($trainee->name)
+            ->assertSee('value="' . $trainee->clan_id . '"', false);
+    }
+
+    #[Test]
+    public function completion_button_hidden_without_a_deep_linked_trainee(): void
+    {
+        $srLdr  = $this->createSeniorLeader(memberAttributes: ['rank' => Rank::STAFF_SERGEANT]);
+        $module = TrainingModule::create([
+            'name'                 => 'General Training',
+            'slug'                 => 'general',
+            'is_active'            => true,
+            'show_completion_form' => true,
+        ]);
+
+        $this->actingAs($srLdr)
+            ->get(route('training.show', ['slug' => $module->slug]))
+            ->assertOk()
+            ->assertDontSee('Mark Training Complete');
+    }
+
+    #[Test]
+    public function completion_button_hidden_when_module_does_not_show_completion_form(): void
+    {
+        $srLdr  = $this->createSeniorLeader(memberAttributes: ['rank' => Rank::STAFF_SERGEANT]);
+        $module = TrainingModule::create([
+            'name'                 => 'General Training',
+            'slug'                 => 'general',
+            'is_active'            => true,
+            'show_completion_form' => false,
+        ]);
+        $trainee = $this->createMember();
+
+        $this->actingAs($srLdr)
+            ->get(route('training.show', ['slug' => $module->slug, 'clan_id' => $trainee->clan_id]))
+            ->assertOk()
+            ->assertDontSee('Mark Training Complete');
+    }
+
+    #[Test]
+    public function submitting_completion_form_updates_trainee_record(): void
+    {
+        $srLdr   = $this->createSeniorLeader(memberAttributes: ['rank' => Rank::STAFF_SERGEANT]);
+        $trainee = $this->createMember(['last_trained_at' => null, 'last_trained_by' => null]);
+
+        $this->actingAs($srLdr)
+            ->post(route('training.update'), [
+                'module'  => 'general',
+                'clan_id' => $trainee->clan_id,
+            ])
+            ->assertRedirect('home');
+
+        $trainee->refresh();
+        $this->assertNotNull($trainee->last_trained_at);
+        $this->assertSame($srLdr->member->clan_id, $trainee->last_trained_by);
+    }
+}


### PR DESCRIPTION
The training module's completion form was gated behind an
unreachable `?training=` query param, so it never showed in
practice. When a member is deep-linked in via `clan_id` (e.g.
from the "SGT Training" link on a member profile), the trainer
already knows who they're training - show a confirm-modal button
to mark it complete instead, updating `last_trained_at` and
`last_trained_by` via the existing `training.update` route.