### PR TITLE
Land squad/platoon fixes that PR #714 missed

### DIFF
--- a/app/Http/Controllers/API/v1/DivisionController.php
+++ b/app/Http/Controllers/API/v1/DivisionController.php
@@ -34,7 +34,7 @@ class DivisionController extends ApiController
         $divisions = Division::active()
             ->orderBy('name')
             ->withoutFloaters()
-            ->shuttingDown(
+            ->withoutShutdown(
                 request()->has('include-shutdown')
             )->get();
 

--- a/app/Http/Controllers/PlatoonController.php
+++ b/app/Http/Controllers/PlatoonController.php
@@ -29,7 +29,7 @@ class PlatoonController extends Controller
         return view('platoon.show', compact('platoon', 'members', 'division', 'unitStats'));
     }
 
-    public function manageSquads($division, $platoon)
+    public function manageSquads(Division $division, Platoon $platoon)
     {
         $platoon->load('squads', 'squads.members', 'squads.leader');
 

--- a/app/Http/Controllers/SquadController.php
+++ b/app/Http/Controllers/SquadController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Data\UnitStatsData;
 use App\Enums\ActivityType;
+use App\Http\Requests\Squad\AssignSquadMemberRequest;
 use App\Models\Division;
 use App\Models\Member;
 use App\Models\Platoon;
@@ -11,7 +12,6 @@ use App\Models\Squad;
 use App\Repositories\SquadRepository;
 use App\Services\MemberQueryService;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
 use Illuminate\Routing\Attributes\Controllers\Middleware;
 
 #[Middleware('auth')]
@@ -33,14 +33,16 @@ class SquadController extends Controller
         return view('squad.show', compact('squad', 'platoon', 'members', 'division', 'unitStats'));
     }
 
-    public function assignMember(Request $request): JsonResponse
+    public function assignMember(AssignSquadMemberRequest $request): JsonResponse
     {
         $member = Member::findOrFail($request->member_id);
 
         if ((int) $request->squad_id === 0) {
-            if ($member->platoon) {
-                $this->authorize('update', $member->platoon);
+            if (! $member->platoon) {
+                return response()->json(['success' => true]);
             }
+
+            $this->authorize('update', $member->platoon);
 
             $member->platoon()->dissociate();
             $member->squad()->dissociate();

--- a/app/Http/Requests/Squad/AssignSquadMemberRequest.php
+++ b/app/Http/Requests/Squad/AssignSquadMemberRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Squad;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class AssignSquadMemberRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'member_id' => 'required|integer|exists:members,id',
+            'squad_id'  => 'required|integer',
+        ];
+    }
+}

--- a/app/Models/Division.php
+++ b/app/Models/Division.php
@@ -203,7 +203,7 @@ class Division extends Model
         $query->whereNotIn('slug', ['bluntz-reserves']);
     }
 
-    public function scopeShuttingDown($query, bool $includeShutdown = false): void
+    public function scopeWithoutShutdown($query, bool $includeShutdown = false): void
     {
         if (! $includeShutdown) {
             $query->whereNull('shutdown_at');
@@ -212,7 +212,7 @@ class Division extends Model
 
     public function scopeRecruitable($query): void
     {
-        $query->active()->shuttingDown()->withoutFloaters()->withoutBR()->orderBy('name');
+        $query->active()->withoutShutdown()->withoutFloaters()->withoutBR()->orderBy('name');
     }
 
     public function sergeants(): HasMany

--- a/app/Policies/SquadPolicy.php
+++ b/app/Policies/SquadPolicy.php
@@ -50,7 +50,7 @@ class SquadPolicy
 
     public static function update(User $user, Squad $squad): bool
     {
-        if ($user->isRole('sr_ldr')) {
+        if ($user->isRole('sr_ldr') && $user->member->division_id === $squad->division->id) {
             return true;
         }
 

--- a/tests/Feature/Controllers/AssignSquadAuthorizationTest.php
+++ b/tests/Feature/Controllers/AssignSquadAuthorizationTest.php
@@ -60,4 +60,64 @@ class AssignSquadAuthorizationTest extends TestCase
         $this->assertEquals($squad->id, $target->squad_id);
         $this->assertEquals($platoon->id, $target->platoon_id);
     }
+
+    #[Test]
+    public function officer_can_unassign_member_from_squad()
+    {
+        $officer = $this->createOfficer();
+        $platoon = $this->createPlatoon($officer->member->division);
+        $squad   = $this->createSquad($platoon);
+        $target  = $this->createMember([
+            'division_id' => $officer->member->division_id,
+            'platoon_id'  => $platoon->id,
+            'squad_id'    => $squad->id,
+        ]);
+
+        $this->actingAs($officer)
+            ->postJson('/members/assign-squad', [
+                'member_id' => $target->id,
+                'squad_id'  => 0,
+            ])->assertOk();
+
+        $target->refresh();
+        $this->assertNotEquals($squad->id, $target->squad_id);
+    }
+
+    #[Test]
+    public function officer_cannot_unassign_member_from_another_divisions_squad()
+    {
+        $division      = $this->createActiveDivision();
+        $otherDivision = $this->createActiveDivision();
+        $platoon       = $this->createPlatoon($division);
+        $squad         = $this->createSquad($platoon);
+        $target        = $this->createMember([
+            'division_id' => $division->id,
+            'platoon_id'  => $platoon->id,
+            'squad_id'    => $squad->id,
+        ]);
+        $officer = $this->createOfficer($otherDivision);
+
+        $this->actingAs($officer)
+            ->postJson('/members/assign-squad', [
+                'member_id' => $target->id,
+                'squad_id'  => 0,
+            ])->assertForbidden();
+
+        $target->refresh();
+        $this->assertEquals($squad->id, $target->squad_id);
+    }
+
+    #[Test]
+    public function unassigning_member_with_no_platoon_is_a_no_op()
+    {
+        $division = $this->createActiveDivision();
+        $user     = $this->createMemberWithUser(['division_id' => $division->id]);
+        $target   = $this->createMember(['division_id' => $division->id, 'platoon_id' => 0, 'squad_id' => 0]);
+
+        $this->actingAs($user)
+            ->postJson('/members/assign-squad', [
+                'member_id' => $target->id,
+                'squad_id'  => 0,
+            ])->assertOk();
+    }
 }

--- a/tests/Unit/Models/DivisionTest.php
+++ b/tests/Unit/Models/DivisionTest.php
@@ -159,24 +159,24 @@ class DivisionTest extends TestCase
     }
 
     #[Test]
-    public function scope_shutting_down_excludes_shutdown_divisions_by_default()
+    public function scope_without_shutdown_excludes_shutdown_divisions_by_default()
     {
         $activeDivision       = Division::factory()->create(['shutdown_at' => null]);
         $shuttingDownDivision = Division::factory()->create(['shutdown_at' => now()]);
 
-        $results = Division::shuttingDown()->get();
+        $results = Division::withoutShutdown()->get();
 
         $this->assertTrue($results->contains($activeDivision));
         $this->assertFalse($results->contains($shuttingDownDivision));
     }
 
     #[Test]
-    public function scope_shutting_down_includes_shutdown_divisions_when_flag_set()
+    public function scope_without_shutdown_includes_shutdown_divisions_when_flag_set()
     {
         $activeDivision       = Division::factory()->create(['shutdown_at' => null]);
         $shuttingDownDivision = Division::factory()->create(['shutdown_at' => now()]);
 
-        $results = Division::shuttingDown(true)->get();
+        $results = Division::withoutShutdown(true)->get();
 
         $this->assertTrue($results->contains($activeDivision));
         $this->assertTrue($results->contains($shuttingDownDivision));

--- a/tests/Unit/Policies/SquadPolicyTest.php
+++ b/tests/Unit/Policies/SquadPolicyTest.php
@@ -39,4 +39,25 @@ class SquadPolicyTest extends TestCase
 
         $this->assertFalse(SquadPolicy::viewAny($user));
     }
+
+    #[Test]
+    public function sr_ldr_can_update_squad_in_own_division()
+    {
+        $division = $this->createActiveDivision();
+        $squad    = $this->createSquad($this->createPlatoon($division));
+        $srLdr    = $this->createSeniorLeader($division);
+
+        $this->assertTrue(SquadPolicy::update($srLdr, $squad));
+    }
+
+    #[Test]
+    public function sr_ldr_cannot_update_squad_in_another_division()
+    {
+        $division      = $this->createActiveDivision();
+        $otherDivision = $this->createActiveDivision();
+        $squad         = $this->createSquad($this->createPlatoon($division));
+        $srLdr         = $this->createSeniorLeader($otherDivision);
+
+        $this->assertFalse(SquadPolicy::update($srLdr, $squad));
+    }
 }


### PR DESCRIPTION
PR #714 merged against a stale `develop` snapshot (`bec89e78`) rather than its actual head at merge time, so these four commits never landed on `main`:

- `Rename Division scope shuttingDown to withoutShutdown`
- `Fix assignMember authorization gap on unassign path`
- `Type-hint manageSquads params for consistency`
- `Scope SquadPolicy::update sr_ldr check to own division`