### PR TITLE
Model cleanup: policy consolidation, dead code, small fixes

### DIFF
--- a/app/Filament/Admin/Resources/DivisionResource.php
+++ b/app/Filament/Admin/Resources/DivisionResource.php
@@ -250,7 +250,7 @@ class DivisionResource extends Resource
             ->color('gray')
             ->requiresConfirmation()
             ->modalHeading('Sync Division DNS')
-            ->modalDescription(fn (CloudflareDnsService $service) => buildDnsPreview($service))
+            ->modalDescription(fn (CloudflareDnsService $service) => $service->previewSync())
             ->modalSubmitActionLabel('Sync Now')
             ->action(function (CloudflareDnsService $service) {
                 try {

--- a/app/Filament/Mod/Resources/RankActionResource.php
+++ b/app/Filament/Mod/Resources/RankActionResource.php
@@ -110,7 +110,7 @@ class RankActionResource extends Resource
                             })
                             ->columnSpanFull(),
                         Livewire::make(Reactions::class)
-                            ->visible(fn ($record) => auth()->user()->canManageRankActionCommentsFor($record)),
+                            ->visible(fn ($record) => auth()->user()->can('manageComments', $record)),
                     ]),
 
             ]);
@@ -225,7 +225,7 @@ class RankActionResource extends Resource
                     ->closeModalByClickingAway(false)
                     ->visible(fn (
                         RankAction $action
-                    ) => auth()->user()->canManageRankActionCommentsFor($action)),
+                    ) => auth()->user()->can('manageComments', $action)),
             ])
             ->toolbarActions([
                 BulkActionGroup::make([

--- a/app/Filament/Mod/Resources/RankActionResource/Pages/CreateRankAction.php
+++ b/app/Filament/Mod/Resources/RankActionResource/Pages/CreateRankAction.php
@@ -68,7 +68,7 @@ class CreateRankAction extends CreateRecord
         $record = $this->record;
 
         // fast track promotions up to platoon lead limit (Cdt <-> PFC)
-        if (auth()->user()->canApproveOrDeny($record)) {
+        if (auth()->user()->can('approve', $record)) {
             $record->approveAndAccept();
             UpdateRankForMember::dispatch($record);
         }

--- a/app/Filament/Mod/Resources/RankActionResource/Pages/EditRankAction.php
+++ b/app/Filament/Mod/Resources/RankActionResource/Pages/EditRankAction.php
@@ -51,7 +51,7 @@ class EditRankAction extends EditRecord
                     ->requiresConfirmation(),
                 Action::make('deny')->label('Deny change')
                     ->color('warning')
-                    ->visible(fn (RankAction $action) => auth()->user()->canApproveOrDeny($action))
+                    ->visible(fn (RankAction $action) => auth()->user()->can('approve', $action))
                     ->hidden(fn ($action) => ! $action->getRecord()->actionable())
                     ->requiresConfirmation()
                     ->modalHeading('Deny Rank Action')
@@ -200,7 +200,7 @@ class EditRankAction extends EditRecord
                             UpdateRankForMember::dispatch($action);
                         }
                     })
-                    ->visible(fn (RankAction $action) => auth()->user()->canApproveOrDeny($action))
+                    ->visible(fn (RankAction $action) => auth()->user()->can('approve', $action))
                     ->hidden(fn ($action) => ! $action->getRecord()->actionable())
                     ->requiresConfirmation()
                     ->modalHeading(fn ($record) => $record->rank->isOfficer()
@@ -218,7 +218,7 @@ class EditRankAction extends EditRecord
                     ->color('warning')
                     ->requiresConfirmation()
                     ->visible(
-                        fn (RankAction $action) => auth()->user()->canApproveOrDeny($action)
+                        fn (RankAction $action) => auth()->user()->can('approve', $action)
                             && $action->rank->value <= Rank::PRIVATE_FIRST_CLASS->value
                     )
                     ->hidden(fn (RankAction $action) => $action->accepted_at && ! $action->actionable())
@@ -236,7 +236,7 @@ class EditRankAction extends EditRecord
         ];
 
         return
-            auth()->user()->canManageRankActionCommentsFor($this->getRecord())
+            auth()->user()->can('manageComments', $this->getRecord())
                 ? array_merge($actions, $commentsAction)
                 : $actions;
     }

--- a/app/Filament/Mod/Resources/TransferResource.php
+++ b/app/Filament/Mod/Resources/TransferResource.php
@@ -153,7 +153,7 @@ class TransferResource extends Resource
                     ->size('lg')
                     ->visible(fn (
                         Transfer $transfer
-                    ) => auth()->user()->canManageTransferCommentsFor($transfer)),
+                    ) => auth()->user()->can('manageComments', $transfer)),
 
                 ActionGroup::make([
                     Action::make('Hold')

--- a/app/Models/Helpers.php
+++ b/app/Models/Helpers.php
@@ -3,9 +3,7 @@
 use App\Jobs\SyncDivisionDns;
 use App\Models\MemberRequest;
 use App\Services\CloudflareDnsService;
-use App\Settings\UserSettings;
 use Carbon\Carbon;
-use Illuminate\Foundation\Application;
 use Illuminate\Support\Arr;
 use Illuminate\Support\HtmlString;
 use Spatie\ScheduleMonitor\Models\MonitoredScheduledTask;
@@ -150,19 +148,6 @@ function doForumFunction(array $ids, $action)
     }
 
     return urldecode($path . http_build_query($params));
-}
-
-/**
- * Get user settings.
- *
- * @param  null  $key
- * @return Application|mixed
- */
-function UserSettings($key = null)
-{
-    $settings = app(UserSettings::class);
-
-    return $key ? $settings->get($key) : $settings;
 }
 
 function hasDivisionIcon($abbreviation)

--- a/app/Models/Helpers.php
+++ b/app/Models/Helpers.php
@@ -204,52 +204,6 @@ function carbon_date_or_null_if_zero($value)
 }
 
 /**
- * Provides visual feedback for a member's last activity
- * based on division activity threshold.
- *
- * @return string
- */
-function getActivityClass($date, $division)
-{
-    $defaultThresholds = [
-        ['days' => 30, 'class' => 'text-danger'],
-        ['days' => 14, 'class' => 'text-warning'],
-    ];
-
-    $limits = $division->settings()
-        ->get('activity_threshold', $defaultThresholds);
-
-    if (! $date instanceof Carbon) {
-        return 'text-danger';
-    }
-
-    $days = $date->diffInDays();
-
-    foreach ($limits as $limit) {
-        if ($days >= $limit['days']) {
-            return $limit['class'];
-        }
-    }
-
-    return 'text-success';
-}
-
-/**
- * Provides visual feedback for a member's last activity
- * for display on their member profile
- *
- * @return string
- */
-function getMemberProfileActivityClass($date)
-{
-    if (! $date instanceof Carbon) {
-        return 'text-muted';
-    } else {
-        return '';
-    }
-}
-
-/**
  * Helper for assigning leadership of platoons, squads.
  *
  * @param  Eloquent|Model  $model

--- a/app/Models/Helpers.php
+++ b/app/Models/Helpers.php
@@ -1,11 +1,8 @@
 <?php
 
-use App\Jobs\SyncDivisionDns;
 use App\Models\MemberRequest;
-use App\Services\CloudflareDnsService;
 use Carbon\Carbon;
 use Illuminate\Support\Arr;
-use Illuminate\Support\HtmlString;
 use Spatie\ScheduleMonitor\Models\MonitoredScheduledTask;
 
 function bytesToHuman($bytes)
@@ -408,37 +405,6 @@ function getAnniversaryTrophy(int $years): ?array
         'color' => '#cd7f32',
         'title' => '5+ Years',
     ];
-}
-
-function buildDnsPreview(CloudflareDnsService $service): HtmlString
-{
-    try {
-        $result   = (new SyncDivisionDns(dryRun: true))->handle($service);
-        $toCreate = collect($result['created']);
-        $toDelete = collect($result['deleted']);
-
-        if ($toCreate->isEmpty() && $toDelete->isEmpty()) {
-            return new HtmlString('<p>No changes needed — DNS is already in sync.</p>');
-        }
-
-        $domain = $service->zoneDomain;
-        $fqdn   = fn (string $s) => "{$s}.{$domain}";
-        $list   = fn ($items) => '<ul style="margin:.25rem 0 0 1rem">'
-            . $items->map(fn ($s) => '<li>' . e($fqdn($s)) . '</li>')->join('')
-            . '</ul>';
-
-        $lines = [];
-        if ($toCreate->isNotEmpty()) {
-            $lines[] = '<strong>Would create:</strong>' . $list($toCreate);
-        }
-        if ($toDelete->isNotEmpty()) {
-            $lines[] = '<strong>Would delete:</strong>' . $list($toDelete);
-        }
-
-        return new HtmlString(implode('', $lines));
-    } catch (Throwable $e) {
-        return new HtmlString('Unable to fetch current DNS records: ' . e($e->getMessage()));
-    }
 }
 
 function scheduledTaskEnabled(string $name): bool

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -339,46 +339,6 @@ class User extends Authenticatable implements Commenter, FilamentUser, HasAvatar
         return $this->isAdminOrDivisionLeader();
     }
 
-    public function canManageRankActionCommentsFor(RankAction $action): bool
-    {
-        $userRank = $this->member->rank;
-        $newRank  = $action->rank;
-
-        // For Sergeant and above, require that the user is at least Master Sergeant
-        if ($newRank->value >= Rank::SERGEANT->value) {
-            return $userRank->value >= Rank::MASTER_SERGEANT->value;
-        }
-
-        // Platoon leaders can manage comments for actions within their authorized rank range
-        if ($this->isWithinPlatoonLimit($newRank, $this->division)) {
-            return true;
-        }
-
-        return $this->isAdminOrDivisionLeader();
-    }
-
-    public function canApproveOrDeny(RankAction $action): bool
-    {
-        $userRank = $this->member->rank;
-        $newRank  = $action->rank;
-
-        if ($newRank->value > $userRank->value) {
-            return false;
-        }
-
-        // Platoon leaders can approve/deny if within their authorized rank range
-        if ($this->isWithinPlatoonLimit($newRank, $this->division)) {
-            return true;
-        }
-
-        // For Sergeant and above, require that the user is at least Command Sergeant
-        if ($newRank->value >= Rank::SERGEANT->value) {
-            return $userRank->value >= Rank::COMMAND_SERGEANT->value;
-        }
-
-        return $this->isAdminOrDivisionLeader();
-    }
-
     public static function findOrCreateForMember(Member $member, ?string $email = null): self
     {
         $user = self::where('member_id', $member->id)->first();
@@ -411,13 +371,6 @@ class User extends Authenticatable implements Commenter, FilamentUser, HasAvatar
         }
 
         return $email;
-    }
-
-    private function isWithinPlatoonLimit(Rank $targetRank, $division): bool
-    {
-        $maxPlRank = Rank::from($division->settings()->get('max_platoon_leader_rank'));
-
-        return $this->isPlatoonLeader() && $targetRank->value <= $maxPlRank->value;
     }
 
     private function isAdminOrDivisionLeader(): bool

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -164,41 +164,25 @@ class User extends Authenticatable implements Commenter, FilamentUser, HasAvatar
 
     public function isMember(): bool
     {
-        if (! $member = $this->member) {
-            return false;
-        }
-
-        return $member->position->value == Position::MEMBER->value;
+        return $this->member?->position === Position::MEMBER;
     }
 
     public function isSquadLeader(): bool
     {
-        if (! $member = $this->member) {
-            return false;
-        }
-
-        return $member->position == Position::SQUAD_LEADER;
+        return $this->member?->position === Position::SQUAD_LEADER;
     }
 
     public function isPlatoonLeader(): bool
     {
-        if (! $member = $this->member) {
-            return false;
-        }
-
-        return $member->position == Position::PLATOON_LEADER;
+        return $this->member?->position === Position::PLATOON_LEADER;
     }
 
     public function isDivisionLeader(): bool
     {
-        if (! $member = $this->member) {
-            return false;
-        }
-
-        return in_array($member->position, [
+        return in_array($this->member?->position, [
             Position::COMMANDING_OFFICER,
             Position::EXECUTIVE_OFFICER,
-        ]);
+        ], true);
     }
 
     public function isDeveloper(): bool

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -334,11 +334,6 @@ class User extends Authenticatable implements Commenter, FilamentUser, HasAvatar
         return $asBoolean ? false : null;
     }
 
-    public function canManageTransferCommentsFor(Transfer $transfer): bool
-    {
-        return $this->isAdminOrDivisionLeader();
-    }
-
     public static function findOrCreateForMember(Member $member, ?string $email = null): self
     {
         $user = self::where('member_id', $member->id)->first();
@@ -373,8 +368,10 @@ class User extends Authenticatable implements Commenter, FilamentUser, HasAvatar
         return $email;
     }
 
-    private function isAdminOrDivisionLeader(): bool
+    public function isWithinPlatoonLimit(Rank $targetRank, $division): bool
     {
-        return $this->isDivisionLeader() || $this->isRole('admin');
+        $maxPlRank = Rank::from($division->settings()->get('max_platoon_leader_rank'));
+
+        return $this->isPlatoonLeader() && $targetRank->value <= $maxPlRank->value;
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -208,25 +208,14 @@ class User extends Authenticatable implements Commenter, FilamentUser, HasAvatar
 
     public function assignRole(Role|string|int $role): void
     {
-        if ($role instanceof Role) {
-            $this->role = $role;
-            $this->save();
+        $roleEnum = match (true) {
+            $role instanceof Role => $role,
+            is_string($role)      => Role::fromSlug($role),
+            is_int($role)         => Role::tryFrom($role),
+        };
 
-            return;
-        }
-
-        if (is_string($role)) {
-            $roleEnum = Role::fromSlug($role);
-            if ($roleEnum) {
-                $this->role = $roleEnum;
-                $this->save();
-
-                return;
-            }
-        }
-
-        if (is_int($role)) {
-            $this->role = $role;
+        if ($roleEnum) {
+            $this->role = $roleEnum;
             $this->save();
         }
     }

--- a/app/Policies/RankActionPolicy.php
+++ b/app/Policies/RankActionPolicy.php
@@ -60,4 +60,54 @@ class RankActionPolicy
     {
         return auth()->user()->isRole(['admin']);
     }
+
+    public static function approve(User $user, RankAction $action): bool
+    {
+        $userRank = $user->member->rank;
+        $newRank  = $action->rank;
+
+        if ($newRank->value > $userRank->value) {
+            return false;
+        }
+
+        if (self::isWithinPlatoonLimit($user, $newRank)) {
+            return true;
+        }
+
+        // For Sergeant and above, require that the user is at least Command Sergeant
+        if ($newRank->value >= Rank::SERGEANT->value) {
+            return $userRank->value >= Rank::COMMAND_SERGEANT->value;
+        }
+
+        return self::isAdminOrDivisionLeader($user);
+    }
+
+    public static function manageComments(User $user, RankAction $action): bool
+    {
+        $userRank = $user->member->rank;
+        $newRank  = $action->rank;
+
+        // For Sergeant and above, require that the user is at least Master Sergeant
+        if ($newRank->value >= Rank::SERGEANT->value) {
+            return $userRank->value >= Rank::MASTER_SERGEANT->value;
+        }
+
+        if (self::isWithinPlatoonLimit($user, $newRank)) {
+            return true;
+        }
+
+        return self::isAdminOrDivisionLeader($user);
+    }
+
+    private static function isWithinPlatoonLimit(User $user, Rank $targetRank): bool
+    {
+        $maxPlRank = Rank::from($user->division->settings()->get('max_platoon_leader_rank'));
+
+        return $user->isPlatoonLeader() && $targetRank->value <= $maxPlRank->value;
+    }
+
+    private static function isAdminOrDivisionLeader(User $user): bool
+    {
+        return $user->isDivisionLeader() || $user->isRole('admin');
+    }
 }

--- a/app/Policies/RankActionPolicy.php
+++ b/app/Policies/RankActionPolicy.php
@@ -70,7 +70,7 @@ class RankActionPolicy
             return false;
         }
 
-        if (self::isWithinPlatoonLimit($user, $newRank)) {
+        if ($user->isWithinPlatoonLimit($newRank, $user->division)) {
             return true;
         }
 
@@ -92,18 +92,11 @@ class RankActionPolicy
             return $userRank->value >= Rank::MASTER_SERGEANT->value;
         }
 
-        if (self::isWithinPlatoonLimit($user, $newRank)) {
+        if ($user->isWithinPlatoonLimit($newRank, $user->division)) {
             return true;
         }
 
         return self::isAdminOrDivisionLeader($user);
-    }
-
-    private static function isWithinPlatoonLimit(User $user, Rank $targetRank): bool
-    {
-        $maxPlRank = Rank::from($user->division->settings()->get('max_platoon_leader_rank'));
-
-        return $user->isPlatoonLeader() && $targetRank->value <= $maxPlRank->value;
     }
 
     private static function isAdminOrDivisionLeader(User $user): bool

--- a/app/Policies/TransferPolicy.php
+++ b/app/Policies/TransferPolicy.php
@@ -65,6 +65,12 @@ class TransferPolicy
             || $this->isLosingDivisionLeader($user, $transfer);
     }
 
+    public function manageComments(User $user, Transfer $transfer): bool
+    {
+        return $this->isGainingDivisionLeader($user, $transfer)
+            || $this->isLosingDivisionLeader($user, $transfer);
+    }
+
     private function isGainingDivisionLeader(User $user, Transfer $transfer): bool
     {
         return $user->division->id === $transfer->division_id && $user->isDivisionLeader();

--- a/app/Presenters/MemberPresenter.php
+++ b/app/Presenters/MemberPresenter.php
@@ -4,6 +4,7 @@ namespace App\Presenters;
 
 use App\Enums\Position;
 use App\Enums\Rank;
+use App\Models\Division;
 use App\Models\Member;
 use Carbon\Carbon;
 use Carbon\CarbonInterface;
@@ -99,5 +100,43 @@ class MemberPresenter extends Presenter
         }
 
         return $this->member->rank->getAbbreviation() . ' ' . $this->member->name;
+    }
+
+    /**
+     * CSS class reflecting the member's voice activity against the
+     * division's activity thresholds, for use in member listings.
+     */
+    public function activityClass(Division $division): string
+    {
+        $date = $this->member->last_voice_activity;
+
+        if (! $date instanceof Carbon) {
+            return 'text-danger';
+        }
+
+        $defaultThresholds = [
+            ['days' => 30, 'class' => 'text-danger'],
+            ['days' => 14, 'class' => 'text-warning'],
+        ];
+
+        $limits = $division->settings()->get('activity_threshold', $defaultThresholds);
+        $days   = $date->diffInDays();
+
+        foreach ($limits as $limit) {
+            if ($days >= $limit['days']) {
+                return $limit['class'];
+            }
+        }
+
+        return 'text-success';
+    }
+
+    /**
+     * CSS class reflecting the member's voice activity, for display
+     * on their member profile.
+     */
+    public function profileActivityClass(): string
+    {
+        return $this->member->last_voice_activity instanceof Carbon ? '' : 'text-muted';
     }
 }

--- a/app/Services/CloudflareDnsService.php
+++ b/app/Services/CloudflareDnsService.php
@@ -2,9 +2,12 @@
 
 namespace App\Services;
 
+use App\Jobs\SyncDivisionDns;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\HtmlString;
+use Throwable;
 
 class CloudflareDnsService
 {
@@ -41,6 +44,36 @@ class CloudflareDnsService
     public function isConfigured(): bool
     {
         return filled($this->zoneId) && filled($this->zoneDomain);
+    }
+
+    public function previewSync(): HtmlString
+    {
+        try {
+            $result   = (new SyncDivisionDns(dryRun: true))->handle($this);
+            $toCreate = collect($result['created']);
+            $toDelete = collect($result['deleted']);
+
+            if ($toCreate->isEmpty() && $toDelete->isEmpty()) {
+                return new HtmlString('<p>No changes needed — DNS is already in sync.</p>');
+            }
+
+            $fqdn = fn (string $s) => "{$s}.{$this->zoneDomain}";
+            $list = fn ($items) => '<ul style="margin:.25rem 0 0 1rem">'
+                . $items->map(fn ($s) => '<li>' . e($fqdn($s)) . '</li>')->join('')
+                . '</ul>';
+
+            $lines = [];
+            if ($toCreate->isNotEmpty()) {
+                $lines[] = '<strong>Would create:</strong>' . $list($toCreate);
+            }
+            if ($toDelete->isNotEmpty()) {
+                $lines[] = '<strong>Would delete:</strong>' . $list($toDelete);
+            }
+
+            return new HtmlString(implode('', $lines));
+        } catch (Throwable $e) {
+            return new HtmlString('Unable to fetch current DNS records: ' . e($e->getMessage()));
+        }
     }
 
     public function listCnames(): Collection

--- a/resources/views/member/partials/general-information.blade.php
+++ b/resources/views/member/partials/general-information.blade.php
@@ -26,7 +26,7 @@
                     <div class="col-md-4 col-xs-12 text-center">
                         <h2 class="no-margins">
                             <span title="{{ $member->last_voice_activity }}"
-                                  class="{{  getMemberProfileActivityClass($member->last_voice_activity) }}">
+                                  class="{{ $member->present()->profileActivityClass() }}">
                                 {{ $member->present()->lastActive('last_voice_activity', skipUnits: ['weeks','months']) }}</span>
                         </h2>
                         Since Last <span class="c-white">Discord Voice Activity</span>

--- a/resources/views/member/partials/member-data-row.blade.php
+++ b/resources/views/member/partials/member-data-row.blade.php
@@ -48,7 +48,7 @@
     @endif
     <td class="text-center hidden-xs hidden-sm">{{ $member->join_date?->format('Y-m-d') }}</td>
     <td class="text-center">
-                    <span class="{{ getActivityClass($member->last_voice_activity, $division) }}"
+                    <span class="{{ $member->present()->activityClass($division) }}"
                           title="{{$member->last_voice_activity}}">
                         {{ $member->present()->lastActive('last_voice_activity', skipUnits: ['weeks', 'months']) }}
                     </span>

--- a/tests/Feature/Services/CloudflareDnsServiceTest.php
+++ b/tests/Feature/Services/CloudflareDnsServiceTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Feature\Services;
+
+use App\Services\CloudflareDnsService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+use Tests\Traits\CreatesDivisions;
+
+class CloudflareDnsServiceTest extends TestCase
+{
+    use CreatesDivisions;
+    use RefreshDatabase;
+
+    protected bool $seed = false;
+
+    private function makeService(array $existingCnames = []): CloudflareDnsService
+    {
+        $service             = Mockery::mock(CloudflareDnsService::class)->makePartial();
+        $service->zoneDomain = 'clanaod.net';
+        $service->shouldReceive('isConfigured')->andReturn(true);
+        $service->shouldReceive('listCnames')->andReturn(collect($existingCnames));
+
+        return $service;
+    }
+
+    #[Test]
+    public function preview_sync_reports_no_changes_needed(): void
+    {
+        $this->createActiveDivision(['name' => 'wow']);
+
+        $service = $this->makeService(['wow' => ['id' => 'rec-1', 'name' => 'wow.clanaod.net']]);
+
+        $this->assertStringContainsString('No changes needed', $service->previewSync()->toHtml());
+    }
+
+    #[Test]
+    public function preview_sync_lists_records_that_would_be_created(): void
+    {
+        $this->createActiveDivision(['name' => 'new-game']);
+
+        $service = $this->makeService();
+
+        $html = $service->previewSync()->toHtml();
+
+        $this->assertStringContainsString('Would create', $html);
+        $this->assertStringContainsString('new-game.clanaod.net', $html);
+    }
+
+    #[Test]
+    public function preview_sync_lists_records_that_would_be_deleted(): void
+    {
+        $this->createInactiveDivision(['name' => 'old-game']);
+
+        $service = $this->makeService(['old-game' => ['id' => 'rec-stale', 'name' => 'old-game.clanaod.net']]);
+
+        $html = $service->previewSync()->toHtml();
+
+        $this->assertStringContainsString('Would delete', $html);
+        $this->assertStringContainsString('old-game.clanaod.net', $html);
+    }
+}

--- a/tests/Unit/Models/UserTest.php
+++ b/tests/Unit/Models/UserTest.php
@@ -371,4 +371,48 @@ class UserTest extends TestCase
 
         $this->assertEquals($member->id . '@placeholder.local', $email);
     }
+
+    #[Test]
+    public function is_within_platoon_limit_true_for_platoon_leader_at_or_below_division_limit()
+    {
+        $division = $this->createActiveDivision();
+        $platoon  = $this->createPlatoon($division);
+
+        $leader = $this->createMemberWithUser([
+            'division_id' => $division->id,
+            'platoon_id'  => $platoon->id,
+            'position'    => Position::PLATOON_LEADER,
+        ]);
+
+        // default max_platoon_leader_rank setting is Rank::PRIVATE_FIRST_CLASS
+        $this->assertTrue($leader->isWithinPlatoonLimit(Rank::PRIVATE_FIRST_CLASS, $division));
+    }
+
+    #[Test]
+    public function is_within_platoon_limit_false_above_division_limit()
+    {
+        $division = $this->createActiveDivision();
+        $platoon  = $this->createPlatoon($division);
+
+        $leader = $this->createMemberWithUser([
+            'division_id' => $division->id,
+            'platoon_id'  => $platoon->id,
+            'position'    => Position::PLATOON_LEADER,
+        ]);
+
+        $this->assertFalse($leader->isWithinPlatoonLimit(Rank::CORPORAL, $division));
+    }
+
+    #[Test]
+    public function is_within_platoon_limit_false_for_non_platoon_leader()
+    {
+        $division = $this->createActiveDivision();
+
+        $user = $this->createMemberWithUser([
+            'division_id' => $division->id,
+            'position'    => Position::MEMBER,
+        ]);
+
+        $this->assertFalse($user->isWithinPlatoonLimit(Rank::PRIVATE_FIRST_CLASS, $division));
+    }
 }

--- a/tests/Unit/Policies/RankActionPolicyTest.php
+++ b/tests/Unit/Policies/RankActionPolicyTest.php
@@ -256,4 +256,155 @@ class RankActionPolicyTest extends TestCase
 
         $this->assertFalse(RankActionPolicy::deleteAny());
     }
+
+    #[Test]
+    public function admin_can_approve_action_within_own_rank()
+    {
+        $admin  = $this->createAdmin();
+        $member = $this->createMember(['division_id' => $admin->member->division_id]);
+
+        $action = RankAction::factory()->create([
+            'member_id' => $member->id,
+            'rank'      => Rank::CORPORAL,
+        ]);
+
+        $this->assertTrue(RankActionPolicy::approve($admin, $action));
+    }
+
+    #[Test]
+    public function user_cannot_approve_action_above_own_rank()
+    {
+        $division = $this->createActiveDivision();
+        $leader   = $this->createMemberWithUser([
+            'division_id' => $division->id,
+            'position'    => Position::COMMANDING_OFFICER,
+            'rank'        => Rank::SERGEANT,
+        ]);
+        $member = $this->createMember(['division_id' => $division->id]);
+
+        $action = RankAction::factory()->create([
+            'member_id' => $member->id,
+            'rank'      => Rank::MASTER_SERGEANT,
+        ]);
+
+        $this->assertFalse(RankActionPolicy::approve($leader, $action));
+    }
+
+    #[Test]
+    public function platoon_leader_can_approve_action_within_platoon_limit()
+    {
+        $division = $this->createActiveDivision();
+        $platoon  = $this->createPlatoon($division);
+
+        $leader = $this->createMemberWithUser([
+            'division_id' => $division->id,
+            'platoon_id'  => $platoon->id,
+            'position'    => Position::PLATOON_LEADER,
+            'rank'        => Rank::STAFF_SERGEANT,
+        ]);
+        $member = $this->createMember(['division_id' => $division->id]);
+
+        // default max_platoon_leader_rank setting is Rank::PRIVATE_FIRST_CLASS
+        $action = RankAction::factory()->create([
+            'member_id' => $member->id,
+            'rank'      => Rank::PRIVATE_FIRST_CLASS,
+        ]);
+
+        $this->assertTrue(RankActionPolicy::approve($leader, $action));
+    }
+
+    #[Test]
+    public function command_sergeant_can_approve_sergeant_rank_action()
+    {
+        $division = $this->createActiveDivision();
+        $leader   = $this->createMemberWithUser([
+            'division_id' => $division->id,
+            'position'    => Position::COMMANDING_OFFICER,
+            'rank'        => Rank::COMMAND_SERGEANT,
+        ]);
+        $member = $this->createMember(['division_id' => $division->id]);
+
+        $action = RankAction::factory()->create([
+            'member_id' => $member->id,
+            'rank'      => Rank::SERGEANT,
+        ]);
+
+        $this->assertTrue(RankActionPolicy::approve($leader, $action));
+    }
+
+    #[Test]
+    public function master_sergeant_cannot_approve_sergeant_rank_action_without_leadership()
+    {
+        $division = $this->createActiveDivision();
+        $user     = $this->createMemberWithUser([
+            'division_id' => $division->id,
+            'position'    => Position::MEMBER,
+            'rank'        => Rank::MASTER_SERGEANT,
+        ]);
+        $member = $this->createMember(['division_id' => $division->id]);
+
+        $action = RankAction::factory()->create([
+            'member_id' => $member->id,
+            'rank'      => Rank::SERGEANT,
+        ]);
+
+        $this->assertFalse(RankActionPolicy::approve($user, $action));
+    }
+
+    #[Test]
+    public function master_sergeant_can_manage_comments_for_sergeant_action()
+    {
+        $division = $this->createActiveDivision();
+        $user     = $this->createMemberWithUser([
+            'division_id' => $division->id,
+            'position'    => Position::MEMBER,
+            'rank'        => Rank::MASTER_SERGEANT,
+        ]);
+        $member = $this->createMember(['division_id' => $division->id]);
+
+        $action = RankAction::factory()->create([
+            'member_id' => $member->id,
+            'rank'      => Rank::SERGEANT,
+        ]);
+
+        $this->assertTrue(RankActionPolicy::manageComments($user, $action));
+    }
+
+    #[Test]
+    public function staff_sergeant_cannot_manage_comments_for_sergeant_action_without_leadership()
+    {
+        $division = $this->createActiveDivision();
+        $user     = $this->createMemberWithUser([
+            'division_id' => $division->id,
+            'position'    => Position::MEMBER,
+            'rank'        => Rank::STAFF_SERGEANT,
+        ]);
+        $member = $this->createMember(['division_id' => $division->id]);
+
+        $action = RankAction::factory()->create([
+            'member_id' => $member->id,
+            'rank'      => Rank::SERGEANT,
+        ]);
+
+        $this->assertFalse(RankActionPolicy::manageComments($user, $action));
+    }
+
+    #[Test]
+    public function division_leader_can_manage_comments_for_low_rank_action()
+    {
+        $division = $this->createActiveDivision();
+        $leader   = $this->createMemberWithUser([
+            'division_id' => $division->id,
+            'position'    => Position::COMMANDING_OFFICER,
+            'rank'        => Rank::STAFF_SERGEANT,
+        ]);
+        $member = $this->createMember(['division_id' => $division->id]);
+
+        $action = RankAction::factory()->create([
+            'member_id' => $member->id,
+            'rank'      => Rank::CORPORAL,
+        ]);
+
+        $this->assertTrue(RankActionPolicy::manageComments($leader, $action));
+    }
 }

--- a/tests/Unit/Policies/TransferPolicyTest.php
+++ b/tests/Unit/Policies/TransferPolicyTest.php
@@ -353,4 +353,68 @@ class TransferPolicyTest extends TestCase
 
         $this->assertFalse($this->policy->hold($leader, $transfer));
     }
+
+    #[Test]
+    public function gaining_division_leader_can_manage_comments()
+    {
+        $fromDivision = $this->createActiveDivision();
+        $toDivision   = $this->createActiveDivision();
+
+        $leader = $this->createMemberWithUser([
+            'division_id' => $toDivision->id,
+            'position'    => Position::COMMANDING_OFFICER,
+        ]);
+
+        $member = $this->createMember(['division_id' => $fromDivision->id]);
+
+        $transfer = Transfer::factory()->pending()->create([
+            'member_id'   => $member->id,
+            'division_id' => $toDivision->id,
+        ]);
+
+        $this->assertTrue($this->policy->manageComments($leader, $transfer));
+    }
+
+    #[Test]
+    public function losing_division_leader_can_manage_comments()
+    {
+        $fromDivision = $this->createActiveDivision();
+        $toDivision   = $this->createActiveDivision();
+
+        $leader = $this->createMemberWithUser([
+            'division_id' => $fromDivision->id,
+            'position'    => Position::COMMANDING_OFFICER,
+        ]);
+
+        $member = $this->createMember(['division_id' => $fromDivision->id]);
+
+        $transfer = Transfer::factory()->pending()->create([
+            'member_id'   => $member->id,
+            'division_id' => $toDivision->id,
+        ]);
+
+        $this->assertTrue($this->policy->manageComments($leader, $transfer));
+    }
+
+    #[Test]
+    public function unrelated_division_leader_cannot_manage_comments()
+    {
+        $fromDivision  = $this->createActiveDivision();
+        $toDivision    = $this->createActiveDivision();
+        $otherDivision = $this->createActiveDivision();
+
+        $leader = $this->createMemberWithUser([
+            'division_id' => $otherDivision->id,
+            'position'    => Position::COMMANDING_OFFICER,
+        ]);
+
+        $member = $this->createMember(['division_id' => $fromDivision->id]);
+
+        $transfer = Transfer::factory()->pending()->create([
+            'member_id'   => $member->id,
+            'division_id' => $toDivision->id,
+        ]);
+
+        $this->assertFalse($this->policy->manageComments($leader, $transfer));
+    }
 }

--- a/tests/Unit/Presenters/MemberPresenterTest.php
+++ b/tests/Unit/Presenters/MemberPresenterTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Unit\Presenters;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+use Tests\Traits\CreatesDivisions;
+use Tests\Traits\CreatesMembers;
+
+class MemberPresenterTest extends TestCase
+{
+    use CreatesDivisions;
+    use CreatesMembers;
+    use RefreshDatabase;
+
+    #[Test]
+    public function activity_class_is_danger_when_never_active()
+    {
+        $division = $this->createActiveDivision();
+        $member   = $this->createMember(['division_id' => $division->id, 'last_voice_activity' => null]);
+
+        $this->assertSame('text-danger', $member->present()->activityClass($division));
+    }
+
+    #[Test]
+    public function activity_class_is_success_within_default_threshold()
+    {
+        $division = $this->createActiveDivision();
+        $member   = $this->createMember([
+            'division_id'         => $division->id,
+            'last_voice_activity' => now()->subDays(5),
+        ]);
+
+        $this->assertSame('text-success', $member->present()->activityClass($division));
+    }
+
+    #[Test]
+    public function activity_class_is_warning_at_fourteen_days()
+    {
+        $division = $this->createActiveDivision();
+        $member   = $this->createMember([
+            'division_id'         => $division->id,
+            'last_voice_activity' => now()->subDays(14),
+        ]);
+
+        $this->assertSame('text-warning', $member->present()->activityClass($division));
+    }
+
+    #[Test]
+    public function activity_class_is_danger_at_thirty_days()
+    {
+        $division = $this->createActiveDivision();
+        $member   = $this->createMember([
+            'division_id'         => $division->id,
+            'last_voice_activity' => now()->subDays(30),
+        ]);
+
+        $this->assertSame('text-danger', $member->present()->activityClass($division));
+    }
+
+    #[Test]
+    public function profile_activity_class_is_empty_when_active()
+    {
+        $member = $this->createMember(['last_voice_activity' => now()]);
+
+        $this->assertSame('', $member->present()->profileActivityClass());
+    }
+
+    #[Test]
+    public function profile_activity_class_is_muted_when_never_active()
+    {
+        $member = $this->createMember(['last_voice_activity' => null]);
+
+        $this->assertSame('text-muted', $member->present()->profileActivityClass());
+    }
+}


### PR DESCRIPTION
Seven independent changes to `app/Models/User.php` and `app/Models/Helpers.php`:

- `RankAction`/`Transfer` comment and approval authorization moved from ad-hoc `User` methods into `RankActionPolicy`/`TransferPolicy`. The Transfer move also fixes a real bug — `canManageTransferCommentsFor()` used a generic admin-or-division-leader check instead of scoping to the transfer's two divisions like `hold()`/`delete()` already did.
- `User::assignRole()` simplified from three near-identical branches to one.
- `User`'s four position-check methods (`isMember`/`isSquadLeader`/`isPlatoonLeader`/`isDivisionLeader`) simplified and made consistently strict.
- Dead global `UserSettings()` function removed (zero callers, name collided with the `App\Settings\UserSettings` class).
- Member activity-class helpers moved from global functions into `MemberPresenter`.
- `buildDnsPreview()` moved from a global function into `CloudflareDnsService::previewSync()`.

New test coverage added for everything moved or fixed.